### PR TITLE
patchfix posthog $pageview failing

### DIFF
--- a/src/services/posthogService.ts
+++ b/src/services/posthogService.ts
@@ -23,7 +23,7 @@ export const initPostHog = async () => {
       defaults: "2026-01-30",
       autocapture: false,
       rageclick: false,
-      capture_pageview: false,
+      capture_pageview: "history_change",
       capture_pageleave: false,
       capture_dead_clicks: false,
       capture_exceptions: false,


### PR DESCRIPTION
This pull request makes a small configuration change to the PostHog analytics initialization. The change updates the `capture_pageview` option to track page views on history changes rather than disabling it.

- Changed the `capture_pageview` option in `initPostHog` (in `src/services/posthogService.ts`) from `false` to `"history_change"`, enabling pageview tracking on history changes.


Summary generated by Copilot.