### PR TITLE
fix incident alerts for PR failures

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -138,7 +138,7 @@ jobs:
       - kill-switch-preflight
       - slack-notify-start
       - build-and-verify
-    if: ${{ always() && needs.kill-switch-preflight.outputs.active != 'true' && needs.slack-notify-start.result == 'success' && github.event_name != 'pull_request' && (needs.build-and-verify.result == 'failure' || needs.build-and-verify.result == 'cancelled') }}
+    if: ${{ always() && needs.kill-switch-preflight.outputs.active != 'true' && needs.slack-notify-start.result == 'success' && (needs.build-and-verify.result == 'failure' || (github.event_name != 'pull_request' && needs.build-and-verify.result == 'cancelled')) }}
     uses: ./.github/workflows/incidentio-workflow-alert.yml
     with:
       status: ${{ needs.build-and-verify.result }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -139,7 +139,7 @@ jobs:
       - kill-switch-preflight
       - slack-notify-start
       - analyze
-    if: ${{ always() && needs.kill-switch-preflight.outputs.active != 'true' && needs.slack-notify-start.result == 'success' && github.event_name != 'pull_request' && (needs.analyze.result == 'failure' || needs.analyze.result == 'cancelled') }}
+    if: ${{ always() && needs.kill-switch-preflight.outputs.active != 'true' && needs.slack-notify-start.result == 'success' && (needs.analyze.result == 'failure' || (github.event_name != 'pull_request' && needs.analyze.result == 'cancelled')) }}
     uses: ./.github/workflows/incidentio-workflow-alert.yml
     with:
       status: ${{ needs.analyze.result }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -146,7 +146,7 @@ jobs:
       - kill-switch-preflight
       - slack-notify-start
       - e2e
-    if: ${{ always() && needs.kill-switch-preflight.outputs.active != 'true' && needs.slack-notify-start.result == 'success' && github.event_name != 'pull_request' && (needs.e2e.result == 'failure' || needs.e2e.result == 'cancelled') }}
+    if: ${{ always() && needs.kill-switch-preflight.outputs.active != 'true' && needs.slack-notify-start.result == 'success' && (needs.e2e.result == 'failure' || (github.event_name != 'pull_request' && needs.e2e.result == 'cancelled')) }}
     uses: ./.github/workflows/incidentio-workflow-alert.yml
     with:
       status: ${{ needs.e2e.result }}

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -125,7 +125,7 @@ jobs:
       - kill-switch-preflight
       - slack-notify-start
       - security-audit
-    if: ${{ always() && needs.kill-switch-preflight.outputs.active != 'true' && needs.slack-notify-start.result == 'success' && github.event_name != 'pull_request' && (needs.security-audit.result == 'failure' || needs.security-audit.result == 'cancelled') }}
+    if: ${{ always() && needs.kill-switch-preflight.outputs.active != 'true' && needs.slack-notify-start.result == 'success' && (needs.security-audit.result == 'failure' || (github.event_name != 'pull_request' && needs.security-audit.result == 'cancelled')) }}
     uses: ./.github/workflows/incidentio-workflow-alert.yml
     with:
       status: ${{ needs.security-audit.result }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated incident notification conditions across multiple CI/CD workflows (build verification, code analysis, security audits, and end-to-end tests)
  * Failure alerts now trigger consistently across all event types; cancellation alerts remain limited to non-pull-request events for cleaner alerting behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->