### PR TITLE
Fix subprocessor notice handling

### DIFF
--- a/supabase/functions/_shared/subprocessorNotice.ts
+++ b/supabase/functions/_shared/subprocessorNotice.ts
@@ -39,10 +39,29 @@ function changeTypeSuffix(t: SubprocessorChangeType): string {
 }
 
 function formatDateLabel(iso: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(iso)) return iso;
   const [year, month, day] = iso.split("-").map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day
+  ) {
+    return iso;
+  }
   const months = [
-    "January", "February", "March", "April", "May", "June",
-    "July", "August", "September", "October", "November", "December",
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
   ];
   return `${months[month - 1]} ${day}, ${year}`;
 }
@@ -51,20 +70,29 @@ export function buildSubprocessorEmailSubject(
   vendor: string,
   changeType: SubprocessorChangeType,
 ): string {
-  return `ItemTraxx Data Processing Notice: Subprocessor ${changeTypeSuffix(changeType)} — ${vendor}`;
+  return `ItemTraxx Data Processing Notice: Subprocessor ${
+    changeTypeSuffix(changeType)
+  } — ${vendor}`;
 }
 
-export function buildSubprocessorNoticeHtml(p: SubprocessorNoticePayload): string {
+export function buildSubprocessorNoticeHtml(
+  p: SubprocessorNoticePayload,
+): string {
   const legalHubUrl = p.legalHubUrl ?? "https://www.itemtraxx.com/legal";
-  const contactSupportUrl = p.contactSupportUrl ?? "https://www.itemtraxx.com/contact-support";
+  const contactSupportUrl = p.contactSupportUrl ??
+    "https://www.itemtraxx.com/contact-support";
   const effectiveDateLabel = formatDateLabel(p.effectiveDate);
   const vendorSafe = escapeHtml(p.vendor);
   const descriptionBlock = p.description
-    ? `<tr><td style="padding:0 0 10px;font-size:14px;color:#444444;line-height:1.6;"><strong>Details:</strong> ${escapeHtml(p.description)}</td></tr>`
+    ? `<tr><td style="padding:0 0 10px;font-size:14px;color:#444444;line-height:1.6;"><strong>Details:</strong> ${
+      escapeHtml(p.description)
+    }</td></tr>`
     : "";
 
   const logoBlock = p.logoUrl
-    ? `<img src="${escapeHtml(p.logoUrl)}" alt="ItemTraxx" height="40" style="display:block;border:0;" />`
+    ? `<img src="${
+      escapeHtml(p.logoUrl)
+    }" alt="ItemTraxx" height="40" style="display:block;border:0;" />`
     : `<span style="font-size:18px;font-weight:700;color:#111111;">ItemTraxx</span>`;
 
   return `<!DOCTYPE html>
@@ -86,7 +114,9 @@ export function buildSubprocessorNoticeHtml(p: SubprocessorNoticePayload): strin
                 <tr>
                   <td style="padding:0 0 16px;">
                     <h1 style="margin:0;font-size:20px;font-weight:700;color:#111111;line-height:1.3;">
-                      Data Processing Notice: Subprocessor ${escapeHtml(changeTypeSuffix(p.changeType))}
+                      Data Processing Notice: Subprocessor ${
+    escapeHtml(changeTypeSuffix(p.changeType))
+  }
                     </h1>
                   </td>
                 </tr>
@@ -108,12 +138,16 @@ export function buildSubprocessorNoticeHtml(p: SubprocessorNoticePayload): strin
                       </tr>
                       <tr>
                         <td style="padding:0 0 10px;font-size:14px;color:#444444;line-height:1.6;">
-                          <strong>Change:</strong> ${vendorSafe} ${escapeHtml(changeTypeLabel(p.changeType))}
+                          <strong>Change:</strong> ${vendorSafe} ${
+    escapeHtml(changeTypeLabel(p.changeType))
+  }
                         </td>
                       </tr>
                       <tr>
                         <td style="padding:0 0 10px;font-size:14px;color:#444444;line-height:1.6;">
-                          <strong>Effective date:</strong> ${escapeHtml(effectiveDateLabel)}
+                          <strong>Effective date:</strong> ${
+    escapeHtml(effectiveDateLabel)
+  }
                         </td>
                       </tr>
                       ${descriptionBlock}
@@ -123,7 +157,9 @@ export function buildSubprocessorNoticeHtml(p: SubprocessorNoticePayload): strin
                 <tr>
                   <td style="padding:0 0 20px;font-size:15px;color:#444444;line-height:1.6;">
                     Under your Data Processing Addendum, you may object to this change in writing before
-                    the effective date (<strong>${escapeHtml(effectiveDateLabel)}</strong>). If you have
+                    the effective date (<strong>${
+    escapeHtml(effectiveDateLabel)
+  }</strong>). If you have
                     questions, wish to object, or need a copy of the updated DPA, please contact us.
                   </td>
                 </tr>
@@ -164,13 +200,18 @@ export function buildSubprocessorNoticeHtml(p: SubprocessorNoticePayload): strin
 </html>`;
 }
 
-export function buildSubprocessorNoticePlainText(p: SubprocessorNoticePayload): string {
+export function buildSubprocessorNoticePlainText(
+  p: SubprocessorNoticePayload,
+): string {
   const legalHubUrl = p.legalHubUrl ?? "https://www.itemtraxx.com/legal";
-  const contactSupportUrl = p.contactSupportUrl ?? "https://www.itemtraxx.com/contact-support";
+  const contactSupportUrl = p.contactSupportUrl ??
+    "https://www.itemtraxx.com/contact-support";
   const effectiveDateLabel = formatDateLabel(p.effectiveDate);
   const descriptionLine = p.description ? `Details: ${p.description}\n` : "";
 
-  return `ItemTraxx Data Processing Notice: Subprocessor ${changeTypeSuffix(p.changeType)}
+  return `ItemTraxx Data Processing Notice: Subprocessor ${
+    changeTypeSuffix(p.changeType)
+  }
 
 You are receiving this notice because your organization has an active ItemTraxx service agreement
 that includes a Data Processing Addendum. Under that agreement, ItemTraxx is required to notify

--- a/supabase/functions/_shared/subprocessorNotice_test.ts
+++ b/supabase/functions/_shared/subprocessorNotice_test.ts
@@ -1,4 +1,7 @@
-import { assertEquals, assertStringIncludes } from "https://deno.land/std@0.177.0/testing/asserts.ts";
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.177.0/testing/asserts.ts";
 import {
   buildSubprocessorEmailSubject,
   buildSubprocessorNoticeHtml,
@@ -47,6 +50,25 @@ Deno.test("buildSubprocessorNoticeHtml: contains effective date", () => {
   assertStringIncludes(html, "August 1, 2026");
 });
 
+Deno.test("buildSubprocessorNoticeHtml: preserves malformed date safely", () => {
+  const html = buildSubprocessorNoticeHtml({
+    ...BASE,
+    effectiveDate: "not-a-date",
+  });
+  assertStringIncludes(html, "not-a-date");
+  assertEquals(html.includes("undefined"), false);
+  assertEquals(html.includes("NaN"), false);
+});
+
+Deno.test("buildSubprocessorNoticeHtml: preserves invalid calendar date safely", () => {
+  const html = buildSubprocessorNoticeHtml({
+    ...BASE,
+    effectiveDate: "2026-02-31",
+  });
+  assertStringIncludes(html, "2026-02-31");
+  assertEquals(html.includes("March 3, 2026"), false);
+});
+
 Deno.test("buildSubprocessorNoticeHtml: contains change type label for added", () => {
   const html = buildSubprocessorNoticeHtml(BASE);
   assertStringIncludes(html, "has been added as a subprocessor");
@@ -63,7 +85,10 @@ Deno.test("buildSubprocessorNoticeHtml: contains change type label for removed",
 });
 
 Deno.test("buildSubprocessorNoticeHtml: optional description rendered", () => {
-  const html = buildSubprocessorNoticeHtml({ ...BASE, description: "Used for transactional email delivery." });
+  const html = buildSubprocessorNoticeHtml({
+    ...BASE,
+    description: "Used for transactional email delivery.",
+  });
   assertStringIncludes(html, "Used for transactional email delivery.");
 });
 
@@ -73,24 +98,36 @@ Deno.test("buildSubprocessorNoticeHtml: omits description block when absent", ()
 });
 
 Deno.test("buildSubprocessorNoticeHtml: escapes HTML in vendor name", () => {
-  const html = buildSubprocessorNoticeHtml({ ...BASE, vendor: '<script>alert("xss")</script>' });
+  const html = buildSubprocessorNoticeHtml({
+    ...BASE,
+    vendor: '<script>alert("xss")</script>',
+  });
   assertEquals(html.includes("<script>"), false);
   assertStringIncludes(html, "&lt;script&gt;");
 });
 
 Deno.test("buildSubprocessorNoticeHtml: escapes HTML in description", () => {
-  const html = buildSubprocessorNoticeHtml({ ...BASE, description: '<img src=x onerror="bad()">' });
+  const html = buildSubprocessorNoticeHtml({
+    ...BASE,
+    description: '<img src=x onerror="bad()">',
+  });
   assertEquals(html.includes("<img"), false);
   assertStringIncludes(html, "&lt;img");
 });
 
 Deno.test("buildSubprocessorNoticeHtml: custom legalHubUrl used", () => {
-  const html = buildSubprocessorNoticeHtml({ ...BASE, legalHubUrl: "https://example.com/dpa" });
+  const html = buildSubprocessorNoticeHtml({
+    ...BASE,
+    legalHubUrl: "https://example.com/dpa",
+  });
   assertStringIncludes(html, "https://example.com/dpa");
 });
 
 Deno.test("buildSubprocessorNoticeHtml: custom contactSupportUrl used", () => {
-  const html = buildSubprocessorNoticeHtml({ ...BASE, contactSupportUrl: "https://example.com/support" });
+  const html = buildSubprocessorNoticeHtml({
+    ...BASE,
+    contactSupportUrl: "https://example.com/support",
+  });
   assertStringIncludes(html, "https://example.com/support");
 });
 
@@ -101,7 +138,10 @@ Deno.test("buildSubprocessorNoticeHtml: falls back to default URLs", () => {
 });
 
 Deno.test("buildSubprocessorNoticeHtml: logo img rendered when logoUrl provided", () => {
-  const html = buildSubprocessorNoticeHtml({ ...BASE, logoUrl: "https://example.com/logo.png" });
+  const html = buildSubprocessorNoticeHtml({
+    ...BASE,
+    logoUrl: "https://example.com/logo.png",
+  });
   assertStringIncludes(html, 'src="https://example.com/logo.png"');
 });
 
@@ -119,7 +159,10 @@ Deno.test("buildSubprocessorNoticePlainText: contains vendor and date", () => {
 });
 
 Deno.test("buildSubprocessorNoticePlainText: optional description present", () => {
-  const text = buildSubprocessorNoticePlainText({ ...BASE, description: "For email delivery." });
+  const text = buildSubprocessorNoticePlainText({
+    ...BASE,
+    description: "For email delivery.",
+  });
   assertStringIncludes(text, "For email delivery.");
 });
 

--- a/supabase/functions/super-ops/index.ts
+++ b/supabase/functions/super-ops/index.ts
@@ -60,6 +60,22 @@ type SafeSupportAttachmentPathParts = {
   extensionSegment: string;
 };
 
+const parseEffectiveDateUtc = (value: string) => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new ValidationError("effective_date must be YYYY-MM-DD", 400);
+  }
+  const [year, month, day] = value.split("-").map(Number);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day
+  ) {
+    throw new ValidationError("effective_date must be a valid date", 400);
+  }
+  return parsed;
+};
+
 const getSafeSupportAttachmentPathParts = (attachment: {
   storage_bucket: string | null;
   storage_path: string | null;
@@ -1902,23 +1918,28 @@ serve(async (req) => {
 
     // ── Subprocessor notice: preview ────────────────────────────────────────────
     if (action === "preview_subprocessor_notice") {
-      const body = asRecord(await readJsonBody(req));
-      const vendor = requireText(body, "vendor", 256);
-      const rawChangeType = requireText(body, "change_type", 32);
+      const vendor = requireText(payload.vendor, { maxLen: 256 });
+      const rawChangeType = requireText(payload.change_type, { maxLen: 32 });
       if (!["added", "replaced", "removed"].includes(rawChangeType)) {
-        throw new ValidationError(400, "change_type must be 'added', 'replaced', or 'removed'");
+        throw new ValidationError(
+          "change_type must be 'added', 'replaced', or 'removed'",
+          400,
+        );
       }
       const changeType = rawChangeType as SubprocessorChangeType;
-      const effectiveDate = requireText(body, "effective_date", 10);
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(effectiveDate)) {
-        throw new ValidationError(400, "effective_date must be YYYY-MM-DD");
+      const effectiveDate = requireText(payload.effective_date, { maxLen: 10 });
+      const effectiveDateUtc = parseEffectiveDateUtc(effectiveDate);
+      const todayUtc = new Date();
+      todayUtc.setUTCHours(0, 0, 0, 0);
+      const thirtyDaysOut = new Date(todayUtc);
+      thirtyDaysOut.setUTCDate(thirtyDaysOut.getUTCDate() + 30);
+      if (effectiveDateUtc < thirtyDaysOut) {
+        throw new ValidationError(
+          "effective_date must be at least 30 days from today",
+          400,
+        );
       }
-      const thirtyDaysOut = new Date();
-      thirtyDaysOut.setDate(thirtyDaysOut.getDate() + 30);
-      if (new Date(effectiveDate) < thirtyDaysOut) {
-        throw new ValidationError(400, "effective_date must be at least 30 days from today");
-      }
-      const description = optionalText(body, "description", 2048) ?? undefined;
+      const description = optionalText(payload.description, { maxLen: 2048 }) || undefined;
 
       const { count: districtCount } = await adminClient
         .from("districts")
@@ -1946,23 +1967,28 @@ serve(async (req) => {
 
     // ── Subprocessor notice: announce (sends emails + creates DB record) ─────────
     if (action === "announce_subprocessor_change") {
-      const body = asRecord(await readJsonBody(req));
-      const vendor = requireText(body, "vendor", 256);
-      const rawChangeType = requireText(body, "change_type", 32);
+      const vendor = requireText(payload.vendor, { maxLen: 256 });
+      const rawChangeType = requireText(payload.change_type, { maxLen: 32 });
       if (!["added", "replaced", "removed"].includes(rawChangeType)) {
-        throw new ValidationError(400, "change_type must be 'added', 'replaced', or 'removed'");
+        throw new ValidationError(
+          "change_type must be 'added', 'replaced', or 'removed'",
+          400,
+        );
       }
       const changeType = rawChangeType as SubprocessorChangeType;
-      const effectiveDate = requireText(body, "effective_date", 10);
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(effectiveDate)) {
-        throw new ValidationError(400, "effective_date must be YYYY-MM-DD");
+      const effectiveDate = requireText(payload.effective_date, { maxLen: 10 });
+      const effectiveDateUtc = parseEffectiveDateUtc(effectiveDate);
+      const todayUtc = new Date();
+      todayUtc.setUTCHours(0, 0, 0, 0);
+      const thirtyDaysOut = new Date(todayUtc);
+      thirtyDaysOut.setUTCDate(thirtyDaysOut.getUTCDate() + 30);
+      if (effectiveDateUtc < thirtyDaysOut) {
+        throw new ValidationError(
+          "effective_date must be at least 30 days from today",
+          400,
+        );
       }
-      const thirtyDaysOut = new Date();
-      thirtyDaysOut.setDate(thirtyDaysOut.getDate() + 30);
-      if (new Date(effectiveDate) < thirtyDaysOut) {
-        throw new ValidationError(400, "effective_date must be at least 30 days from today");
-      }
-      const description = optionalText(body, "description", 2048) ?? undefined;
+      const description = optionalText(payload.description, { maxLen: 2048 }) || undefined;
 
       const resendApiKey = Deno.env.get("ITX_RESEND_API_KEY");
       if (!resendApiKey) {
@@ -2031,7 +2057,9 @@ serve(async (req) => {
               recipientEmail,
               subject,
               provider: "resend",
-              requestContext: "super-ops/announce_subprocessor_change",
+              requestContext: {
+                source: "super-ops/announce_subprocessor_change",
+              },
               triggeredByUserId: user.id,
               tenantId: null,
               districtId: null,


### PR DESCRIPTION
## Summary
- reuse validated super-ops request payloads
- validate UTC effective dates and malformed formatter input
- correct email request context typing

## Validation
- `deno test supabase/functions/_shared/subprocessorNotice_test.ts`
- `deno check supabase/functions/super-ops/index.ts`
- `npm run build`

`npm run security:gate` remains blocked by the existing no-fix esbuild advisory.