### PR TITLE
fix: prevent checkout/return race conditions and duplicate transactions

### DIFF
--- a/src/services/checkoutService.ts
+++ b/src/services/checkoutService.ts
@@ -10,6 +10,7 @@ type CheckoutReturnPayload = {
   action_type: "checkout" | "return" | "auto" | "admin_return";
   device_id?: string;
   device_label?: string;
+  operation_id?: string;
 };
 
 type SubmitCheckoutReturnResult = {
@@ -36,7 +37,10 @@ type BufferedCheckoutItem = {
 const LOOKUP_TIMEOUT_MS = 7000;
 const OFFLINE_QUEUE_KEY = "itemtraxx:checkout-offline-buffer:v1";
 const OFFLINE_QUEUE_KEY_VERSION = "itemtraxx:checkout-offline-buffer:key:v1";
+const OFFLINE_QUEUE_LOCK_KEY = "itemtraxx:checkout-offline-buffer:lock:v1";
 const OFFLINE_QUEUE_ALGO = "AES-GCM";
+const OFFLINE_QUEUE_LOCK_TTL_MS = 30_000;
+const OFFLINE_QUEUE_LOCK_REFRESH_MS = 1_000;
 let offlineQueueWarning: string | null = null;
 
 const isRetryableNetworkFailure = (status: number, message: string) => {
@@ -66,6 +70,99 @@ const buildFallbackCryptoKey = () => {
   const seed = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const encoder = new TextEncoder();
   return bytesToBase64(encoder.encode(seed));
+};
+
+const createOperationId = () =>
+  typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `op-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+const ensureOperationId = (payload: CheckoutReturnPayload): CheckoutReturnPayload => ({
+  ...payload,
+  operation_id: payload.operation_id ?? createOperationId(),
+});
+
+const sleep = (ms: number) => new Promise((resolve) => window.setTimeout(resolve, ms));
+
+const runWithStorageLease = async <T>(callback: () => Promise<T>) => {
+  const owner = createOperationId();
+  const acquireStartedAt = Date.now();
+  let heartbeatId: number | null = null;
+
+  const renewLease = () => {
+    window.localStorage.setItem(
+      OFFLINE_QUEUE_LOCK_KEY,
+      JSON.stringify({
+        owner,
+        expires_at: Date.now() + OFFLINE_QUEUE_LOCK_TTL_MS,
+      })
+    );
+  };
+
+  while (true) {
+    const now = Date.now();
+    const raw = window.localStorage.getItem(OFFLINE_QUEUE_LOCK_KEY);
+    let currentOwner = "";
+    let expiresAt = 0;
+
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as { owner?: string; expires_at?: number };
+        currentOwner = typeof parsed.owner === "string" ? parsed.owner : "";
+        expiresAt = typeof parsed.expires_at === "number" ? parsed.expires_at : 0;
+      } catch {
+        window.localStorage.removeItem(OFFLINE_QUEUE_LOCK_KEY);
+      }
+    }
+
+    if (!currentOwner || expiresAt <= now || currentOwner === owner) {
+      renewLease();
+      try {
+        const confirmed = JSON.parse(
+          window.localStorage.getItem(OFFLINE_QUEUE_LOCK_KEY) ?? "{}"
+        ) as { owner?: string };
+        if (confirmed.owner === owner) {
+          heartbeatId = window.setInterval(renewLease, OFFLINE_QUEUE_LOCK_REFRESH_MS);
+          break;
+        }
+      } catch {
+        window.localStorage.removeItem(OFFLINE_QUEUE_LOCK_KEY);
+      }
+    }
+
+    if (Date.now() - acquireStartedAt > OFFLINE_QUEUE_LOCK_TTL_MS * 2) {
+      throw new Error("Offline queue is busy. Please try again.");
+    }
+
+    await sleep(50);
+  }
+
+  try {
+    return await callback();
+  } finally {
+    if (heartbeatId !== null) {
+      window.clearInterval(heartbeatId);
+    }
+    try {
+      const current = JSON.parse(
+        window.localStorage.getItem(OFFLINE_QUEUE_LOCK_KEY) ?? "{}"
+      ) as { owner?: string };
+      if (current.owner === owner) {
+        window.localStorage.removeItem(OFFLINE_QUEUE_LOCK_KEY);
+      }
+    } catch {
+      window.localStorage.removeItem(OFFLINE_QUEUE_LOCK_KEY);
+    }
+  }
+};
+
+const withOfflineQueueLock = async <T>(callback: () => Promise<T>) => {
+  if (typeof navigator !== "undefined" && "locks" in navigator && navigator.locks) {
+    return navigator.locks.request("itemtraxx-checkout-offline-buffer", { mode: "exclusive" }, callback);
+  }
+  // Fallback only for browsers without Web Locks support. This localStorage lease is
+  // best-effort and may still allow rare split-brain acquisition under tight interleaving.
+  return runWithStorageLease(callback);
 };
 
 const getOrCreateOfflineQueueKey = async () => {
@@ -204,22 +301,23 @@ const writeOfflineQueue = async (items: BufferedCheckoutItem[]) => {
   }
 };
 
-const queueCheckoutPayload = async (payload: CheckoutReturnPayload, error: string | null = null) => {
-  const queue = await readOfflineQueue();
-  const item: BufferedCheckoutItem = {
-    id:
-      typeof crypto !== "undefined" && "randomUUID" in crypto
-        ? crypto.randomUUID()
-        : `queued-${Date.now()}-${Math.random().toString(16).slice(2)}`,
-    payload,
-    created_at: new Date().toISOString(),
-    attempts: 0,
-    last_error: error,
-  };
-  queue.push(item);
-  await writeOfflineQueue(queue);
-  return queue.length;
-};
+const queueCheckoutPayload = async (payload: CheckoutReturnPayload, error: string | null = null) =>
+  withOfflineQueueLock(async () => {
+    const queue = await readOfflineQueue();
+    const item: BufferedCheckoutItem = {
+      id:
+        typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? crypto.randomUUID()
+          : `queued-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      payload: ensureOperationId(payload),
+      created_at: new Date().toISOString(),
+      attempts: 0,
+      last_error: error,
+    };
+    queue.push(item);
+    await writeOfflineQueue(queue);
+    return queue.length;
+  });
 
 const executeCheckoutReturn = async (payload: CheckoutReturnPayload) => {
   const { deviceId, deviceLabel } = getOrCreateDeviceSession();
@@ -258,64 +356,74 @@ const executeCheckoutReturn = async (payload: CheckoutReturnPayload) => {
 export const submitCheckoutReturn = async (
   payload: CheckoutReturnPayload
 ): Promise<SubmitCheckoutReturnResult> => {
+  const payloadWithOperationId = ensureOperationId(payload);
   try {
-    await executeCheckoutReturn(payload);
-    return { buffered: false, queuedCount: (await readOfflineQueue()).length };
+    await executeCheckoutReturn(payloadWithOperationId);
+    return {
+      buffered: false,
+      queuedCount: await withOfflineQueueLock(async () => (await readOfflineQueue()).length),
+    };
   } catch (error) {
     const message = error instanceof Error ? error.message : "Request failed.";
     if (isRetryableNetworkFailure(0, message)) {
       if (navigator.onLine) {
         try {
-          await executeCheckoutReturn(payload);
-          return { buffered: false, queuedCount: (await readOfflineQueue()).length };
+          await executeCheckoutReturn(payloadWithOperationId);
+          return {
+            buffered: false,
+            queuedCount: await withOfflineQueueLock(async () => (await readOfflineQueue()).length),
+          };
         } catch (retryError) {
           throw retryError;
         }
       }
-      const queuedCount = await queueCheckoutPayload(payload, message);
+      const queuedCount = await queueCheckoutPayload(payloadWithOperationId, message);
       return { buffered: true, queuedCount };
     }
     throw error;
   }
 };
 
-export const getBufferedCheckoutCount = async () => (await readOfflineQueue()).length;
+export const getBufferedCheckoutCount = async () =>
+  withOfflineQueueLock(async () => (await readOfflineQueue()).length);
 
-export const syncBufferedCheckoutQueue = async () => {
-  const queue = await readOfflineQueue();
-  if (queue.length === 0) {
-    return { processed: 0, failed: 0, remaining: 0 };
-  }
+export const syncBufferedCheckoutQueue = async () =>
+  withOfflineQueueLock(async () => {
+    const queue = await readOfflineQueue();
+    if (queue.length === 0) {
+      return { processed: 0, failed: 0, remaining: 0 };
+    }
 
-  let processed = 0;
-  let failed = 0;
-  const remaining: BufferedCheckoutItem[] = [];
+    let processed = 0;
+    let failed = 0;
+    const remaining: BufferedCheckoutItem[] = [];
 
-  for (const item of queue) {
-    try {
-      await executeCheckoutReturn(item.payload);
-      processed += 1;
-    } catch (error) {
-      failed += 1;
-      const message = error instanceof Error ? error.message : "Request failed.";
-      // Keep retryable network failures in the buffer, drop permanent authorization/policy failures.
-      if (isRetryableNetworkFailure(0, message)) {
-        remaining.push({
-          ...item,
-          attempts: item.attempts + 1,
-          last_error: message,
-        });
+    for (const item of queue) {
+      const payload = ensureOperationId(item.payload);
+      try {
+        await executeCheckoutReturn(payload);
+        processed += 1;
+      } catch (error) {
+        failed += 1;
+        const message = error instanceof Error ? error.message : "Request failed.";
+        if (isRetryableNetworkFailure(0, message)) {
+          remaining.push({
+            ...item,
+            payload,
+            attempts: item.attempts + 1,
+            last_error: message,
+          });
+        }
       }
     }
-  }
 
-  await writeOfflineQueue(remaining);
-  return {
-    processed,
-    failed,
-    remaining: remaining.length,
-  };
-};
+    await writeOfflineQueue(remaining);
+    return {
+      processed,
+      failed,
+      remaining: remaining.length,
+    };
+  });
 
 export type StudentSummary = {
   id: string;

--- a/supabase/functions/checkoutReturn/index.ts
+++ b/supabase/functions/checkoutReturn/index.ts
@@ -193,8 +193,8 @@ serve(async (req) => {
       maxLen: 64,
       pattern: BARCODE_PATTERN,
     });
-    const operationId = optionalText(operation_id, { maxLen: 128 }) ??
-      req.headers.get("x-request-id")?.trim() ??
+    const operationId = optionalText(operation_id, { maxLen: 128 }) ||
+      req.headers.get("x-request-id")?.trim() ||
       crypto.randomUUID();
 
     const adminClient = createClient(supabaseUrl, serviceKey, {

--- a/supabase/functions/checkoutReturn/index.ts
+++ b/supabase/functions/checkoutReturn/index.ts
@@ -193,8 +193,11 @@ serve(async (req) => {
       maxLen: 64,
       pattern: BARCODE_PATTERN,
     });
+    const requestIdFallback = optionalText(req.headers.get("x-request-id"), {
+      maxLen: 128,
+    });
     const operationId = optionalText(operation_id, { maxLen: 128 }) ||
-      req.headers.get("x-request-id")?.trim() ||
+      requestIdFallback ||
       crypto.randomUUID();
 
     const adminClient = createClient(supabaseUrl, serviceKey, {

--- a/supabase/functions/checkoutReturn/index.ts
+++ b/supabase/functions/checkoutReturn/index.ts
@@ -30,6 +30,12 @@ const CHECKOUT_ACTIONS = new Set(
   ["checkout", "return", "auto", "admin_return"] as const,
 );
 
+const buildGearLogOperationId = (
+  operationId: string,
+  gearId: string,
+  actionType: "checkout" | "return" | "admin_return",
+) => `${operationId}:${gearId}:${actionType}`;
+
 const resolveCorsHeaders = (req: Request) => {
   const origin = req.headers.get("Origin");
   const allowedOrigins = parseAllowedOrigins(
@@ -178,7 +184,7 @@ serve(async (req) => {
       });
     }
 
-    const { student_id, gear_barcodes, action_type, device_id } =
+    const { student_id, gear_barcodes, action_type, device_id, operation_id } =
       await readJsonBody(req);
     const actionType = requireEnum(action_type, CHECKOUT_ACTIONS);
     const gearBarcodes = requireTextArray(gear_barcodes, {
@@ -187,6 +193,9 @@ serve(async (req) => {
       maxLen: 64,
       pattern: BARCODE_PATTERN,
     });
+    const operationId = optionalText(operation_id, { maxLen: 128 }) ??
+      req.headers.get("x-request-id")?.trim() ??
+      crypto.randomUUID();
 
     const adminClient = createClient(supabaseUrl, serviceKey, {
       auth: { persistSession: false },
@@ -280,6 +289,32 @@ serve(async (req) => {
         continue;
       }
 
+      const existingOperationId = buildGearLogOperationId(
+        operationId,
+        gear.id,
+        isAdminReturn ? "admin_return" : "checkout",
+      );
+      const existingReturnOperationId = buildGearLogOperationId(
+        operationId,
+        gear.id,
+        "return",
+      );
+      const { data: existingOperation } = await adminClient
+        .from("gear_logs")
+        .select("id")
+        .eq("tenant_id", callerProfile.tenant_id)
+        .eq("gear_id", gear.id)
+        .in("operation_id", isAdminReturn
+          ? [existingOperationId]
+          : [existingOperationId, existingReturnOperationId])
+        .limit(1)
+        .maybeSingle();
+
+      if (existingOperation?.id) {
+        processed += 1;
+        continue;
+      }
+
       if (isAdminReturn) {
         const normalizedStatus = String(gear.status ?? "").toLowerCase();
         if (!gear.checked_out_by || normalizedStatus !== "checked_out") {
@@ -296,6 +331,7 @@ serve(async (req) => {
           })
           .eq("id", gear.id)
           .eq("tenant_id", callerProfile.tenant_id)
+          .eq("status", "checked_out")
           .not("checked_out_by", "is", null)
           .select("id")
           .maybeSingle();
@@ -305,12 +341,24 @@ serve(async (req) => {
           continue;
         }
 
-        await adminClient.from("gear_logs").insert({
+        const { error: logError } = await adminClient.from("gear_logs").upsert({
           gear_id: gear.id,
           action_type: "admin_return",
           checked_out_by: gear.checked_out_by,
           tenant_id: callerProfile.tenant_id,
+          operation_id: buildGearLogOperationId(operationId, gear.id, "admin_return"),
+        }, {
+          onConflict: "tenant_id,gear_id,action_type,operation_id",
+          ignoreDuplicates: true,
         });
+
+        if (logError) {
+          console.error("checkoutReturn admin log write failed", {
+            gearId: gear.id,
+            operationId,
+            message: logError.message,
+          });
+        }
 
         processed += 1;
         continue;
@@ -338,8 +386,8 @@ serve(async (req) => {
         .eq("tenant_id", callerProfile.tenant_id);
 
       const { data: updatedGear, error: updateError } = await (isCheckout
-        ? updateBuilder.is("checked_out_by", null)
-        : updateBuilder.eq("checked_out_by", student!.id))
+        ? updateBuilder.is("checked_out_by", null).eq("status", "available")
+        : updateBuilder.eq("checked_out_by", student!.id).eq("status", "checked_out"))
         .select("id")
         .maybeSingle();
 
@@ -348,12 +396,26 @@ serve(async (req) => {
         continue;
       }
 
-      await adminClient.from("gear_logs").insert({
+      const resolvedActionType = isCheckout ? "checkout" : "return";
+      const { error: logError } = await adminClient.from("gear_logs").upsert({
         gear_id: gear.id,
-        action_type: isCheckout ? "checkout" : "return",
+        action_type: resolvedActionType,
         checked_out_by: student!.id,
         tenant_id: callerProfile.tenant_id,
+        operation_id: buildGearLogOperationId(operationId, gear.id, resolvedActionType),
+      }, {
+        onConflict: "tenant_id,gear_id,action_type,operation_id",
+        ignoreDuplicates: true,
       });
+
+      if (logError) {
+        console.error("checkoutReturn gear log write failed", {
+          gearId: gear.id,
+          operationId,
+          actionType: resolvedActionType,
+          message: logError.message,
+        });
+      }
 
       processed += 1;
     }

--- a/supabase/sql/checkout_offline_idempotency.sql
+++ b/supabase/sql/checkout_offline_idempotency.sql
@@ -1,0 +1,6 @@
+alter table if exists public.gear_logs
+  add column if not exists operation_id text;
+
+create unique index if not exists idx_gear_logs_operation_dedupe
+  on public.gear_logs (tenant_id, gear_id, action_type, operation_id)
+  where operation_id is not null;


### PR DESCRIPTION
## Summary
Fixes race conditions in the checkout/return flow that could
double-apply transactions, flip gear state on retry, or corrupt the
offline buffer when used across multiple tabs.

## Changes
- **Status-aware CAS guards** (`checkoutReturn`): gear state updates now
match on both `checked_out_by` and `status`, closing a TOCTOU window
where a concurrent status change (e.g. `lost`/`maintenance`) could be
clobbered.
- **Operation-level idempotency**: requests function pre-checks for an
existing log entry before mutating and upserts `gear_logs` with
`ignoreDuplicates`. Prevents duplicate audit rows and the
`auto`-actionstate-flip on replay.
- **New migration** (`checkout_offline_idempotency.sql`): adds
`gear_logs.operation_id` plus a partial unique index `(tenant_id,
gear_id, action_type, operation
- **Cross-tab offline buffer lock** (`checkoutService`): serializes all
buffer reads/writes via the Web Locks API
(localStorage-lease fallback), so concurrentplay or drop buffered
transactions. Buffereditems persist a stable `operation_id` so retries
stay idempotent end-to-end.

## Deploy notes
- Run `checkout_offline_idempotency.sql` **bfunction goes live — the
upsert depends onthe new column/index. (Already applied to the target
environment.)
- Edge function auto-deploys on merge to `ma`.

## Validation
- `npm run test:e2e` ✅
- `npm run build` (vue-tsc + vite) ✅
- `npm run security:gate` ✅ (0 vulns moderate+)
- `npm run perf:budget` + `perf:images` ✅