### PR TITLE
fix(ci): stop blank Slack status posts & patch high-sev SBOM tool vuln

### DIFF
--- a/.github/workflows/async-job-worker.yml
+++ b/.github/workflows/async-job-worker.yml
@@ -56,7 +56,7 @@ jobs:
     needs:
       - slack-notify-start
       - process-jobs
-    if: ${{ always() && needs.process-jobs.result != 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.process-jobs.result != 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish
@@ -80,7 +80,7 @@ jobs:
       - kill-switch-preflight
       - slack-notify-start
       - process-jobs
-    if: ${{ always() && needs.kill-switch-preflight.outputs.active == 'true' && needs.process-jobs.result == 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.kill-switch-preflight.outputs.active == 'true' && needs.process-jobs.result == 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -113,7 +113,7 @@ jobs:
       - kill-switch-preflight
       - slack-notify-start
       - build-and-verify
-    if: ${{ always() && needs.kill-switch-preflight.outputs.active == 'true' && needs.build-and-verify.result == 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.kill-switch-preflight.outputs.active == 'true' && needs.build-and-verify.result == 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -114,7 +114,7 @@ jobs:
       - kill-switch-preflight
       - slack-notify-start
       - analyze
-    if: ${{ always() && needs.kill-switch-preflight.outputs.active == 'true' && needs.analyze.result == 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.kill-switch-preflight.outputs.active == 'true' && needs.analyze.result == 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish

--- a/.github/workflows/deploy-cloudflare-worker.yml
+++ b/.github/workflows/deploy-cloudflare-worker.yml
@@ -71,7 +71,7 @@ jobs:
     needs:
       - slack-notify-start
       - deploy
-    if: ${{ always() && needs.deploy.result != 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.deploy.result != 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish
@@ -95,7 +95,7 @@ jobs:
       - kill-switch-preflight
       - slack-notify-start
       - deploy
-    if: ${{ always() && needs.kill-switch-preflight.outputs.active == 'true' && needs.deploy.result == 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.kill-switch-preflight.outputs.active == 'true' && needs.deploy.result == 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish

--- a/.github/workflows/deploy-supabase-functions.yml
+++ b/.github/workflows/deploy-supabase-functions.yml
@@ -89,7 +89,7 @@ jobs:
     needs:
       - slack-notify-start
       - deploy
-    if: ${{ always() && needs.deploy.result != 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.deploy.result != 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish
@@ -113,7 +113,7 @@ jobs:
       - kill-switch-preflight
       - slack-notify-start
       - deploy
-    if: ${{ always() && needs.kill-switch-preflight.outputs.active == 'true' && needs.deploy.result == 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.kill-switch-preflight.outputs.active == 'true' && needs.deploy.result == 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish

--- a/.github/workflows/deployment-health.yml
+++ b/.github/workflows/deployment-health.yml
@@ -151,7 +151,7 @@ jobs:
     needs:
       - slack-notify-start
       - health-check
-    if: ${{ always() && needs.health-check.result != 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.health-check.result != 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish
@@ -175,7 +175,7 @@ jobs:
       - kill-switch-preflight
       - slack-notify-start
       - health-check
-    if: ${{ always() && needs.kill-switch-preflight.outputs.active == 'true' && needs.health-check.result == 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.kill-switch-preflight.outputs.active == 'true' && needs.health-check.result == 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -120,7 +120,7 @@ jobs:
       - kill-switch-preflight
       - slack-notify-start
       - e2e
-    if: ${{ always() && needs.kill-switch-preflight.outputs.active == 'true' && needs.e2e.result == 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.kill-switch-preflight.outputs.active == 'true' && needs.e2e.result == 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish

--- a/.github/workflows/manage-kill-switch.yml
+++ b/.github/workflows/manage-kill-switch.yml
@@ -123,7 +123,7 @@ jobs:
     needs:
       - slack-notify-start
       - apply
-    if: ${{ always() && needs.apply.result != 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.apply.result != 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish

--- a/.github/workflows/schedule-watchdog.yml
+++ b/.github/workflows/schedule-watchdog.yml
@@ -215,22 +215,47 @@ jobs:
       - kill-switch-preflight
       - check-stale-schedules
     if: ${{ always() && needs.kill-switch-preflight.outputs.active == 'true' && needs.check-stale-schedules.result == 'skipped' }}
-    uses: ./.github/workflows/slack-notify-status.yml
-    with:
-      mode: finish
-      workflow_name: Schedule Watchdog
-      job_name: check-stale-schedules
-      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      ref_name: ${{ github.ref_name }}
-      sha: ${{ github.sha }}
-      status: success
-      status_message: ${{ format('Intentionally skipped because the ItemTraxx kill switch is active. {0}', needs.kill-switch-preflight.outputs.message) }}
-    secrets:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      INCIDENT_IO_WEBHOOK_URL: ${{ secrets.INCIDENT_IO_WEBHOOK_URL }}
-      INCIDENT_IO_WEBHOOK_TOKEN: ${{ secrets.INCIDENT_IO_WEBHOOK_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack kill-switch skip notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+          STATUS_MESSAGE: ${{ format('Intentionally skipped because the ItemTraxx kill switch is active. {0}', needs.kill-switch-preflight.outputs.message) }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+            echo "No Slack webhook configured; skipping."
+            exit 0
+          fi
+          PAYLOAD="$(jq -n \
+            --arg run_url "$RUN_URL" \
+            --arg repo "$REPOSITORY" \
+            --arg branch "$REF_NAME" \
+            --arg commit "${SHA:0:7}" \
+            --arg status_message "$STATUS_MESSAGE" \
+            '{
+              text: "GitHub Actions run skipped",
+              attachments: [
+                {
+                  color: "#d4a017",
+                  fields: [
+                    { title: "Status", value: "Skipped", short: true },
+                    { title: "Commit", value: ($commit + " (" + $branch + ")"), short: true },
+                    if ($status_message != "") then { title: "Message", value: $status_message, short: false } else empty end,
+                    { title: "Workflow", value: ("<" + $run_url + "|Schedule Watchdog / check-stale-schedules>"), short: false },
+                    { title: "Repository", value: $repo, short: false }
+                  ],
+                  footer: "GitHub Actions"
+                }
+              ]
+            }')"
+          curl -fsSL -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            --data "$PAYLOAD"
 
   incidentio-notify-failure:
     needs:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -58,8 +58,6 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Run security gate
-        env:
-          ITX_AUDIT_ALLOW_SOURCES: "1121192"
         run: npm run security:gate
 
       - name: Generate SBOM

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -102,7 +102,7 @@ jobs:
       - kill-switch-preflight
       - slack-notify-start
       - security-audit
-    if: ${{ always() && needs.kill-switch-preflight.outputs.active == 'true' && needs.security-audit.result == 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.kill-switch-preflight.outputs.active == 'true' && needs.security-audit.result == 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish

--- a/.github/workflows/slack-notify-status.yml
+++ b/.github/workflows/slack-notify-status.yml
@@ -211,47 +211,6 @@ jobs:
             fi
           fi
 
-          send_webhook_fallback() {
-            if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
-              PAYLOAD="$(jq -n \
-                --arg workflow "$WORKFLOW_NAME" \
-                --arg job "$JOB_NAME" \
-                --arg branch "$REF_NAME" \
-                --arg commit "${SHA:0:7}" \
-                --arg run_url "$RUN_URL" \
-                --arg status_label "$STATUS_LABEL" \
-                --arg status_message "$STATUS_MESSAGE" \
-                --arg repo "$REPOSITORY" \
-                '{
-                  text: ("GitHub Actions run " + ($status_label | ascii_downcase) + ": " + $workflow + " / " + $job),
-                  attachments: [
-                    {
-                      color: (
-                        if ($status_label == "Succeeded") then "#2eb67d"
-                        elif ($status_label == "Failed") then "#e01e5a"
-                        elif ($status_label == "Cancelled") then "#9ca3af"
-                        else "#d4a017"
-                        end
-                      ),
-                      fields: [
-                        { title: "Status", value: $status_label, short: true },
-                        { title: "Commit", value: ($commit + " (" + $branch + ")"), short: true },
-                        if ($status_message != "") then { title: "Message", value: $status_message, short: false } else empty end,
-                        { title: "Workflow", value: ("<" + $run_url + "|" + $workflow + " / " + $job + ">"), short: false },
-                        { title: "Repository", value: $repo, short: false }
-                      ],
-                      footer: "GitHub Actions"
-                    }
-                  ]
-                }')"
-              curl -fsSL -X POST "$SLACK_WEBHOOK_URL" \
-                -H "Content-Type: application/json" \
-                --data "$PAYLOAD"
-            else
-              echo "No Slack secrets configured; skipping finish notification."
-            fi
-          }
-
           STATUS_LOWER="$(printf '%s' "$STATUS" | tr '[:upper:]' '[:lower:]')"
           case "$STATUS_LOWER" in
             success)
@@ -271,56 +230,55 @@ jobs:
               ;;
           esac
 
-          if [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n "${MESSAGE_CHANNEL_ID:-}" ] && [ -n "${MESSAGE_TS:-}" ]; then
-            PAYLOAD="$(jq -n \
-              --arg channel "$MESSAGE_CHANNEL_ID" \
-              --arg ts "$MESSAGE_TS" \
-              --arg workflow "$WORKFLOW_NAME" \
-              --arg job "$JOB_NAME" \
-              --arg branch "$REF_NAME" \
-              --arg commit "${SHA:0:7}" \
-              --arg repo "$REPOSITORY" \
-              --arg run_url "$RUN_URL" \
-              --arg status_label "$STATUS_LABEL" \
-              --arg status_message "$STATUS_MESSAGE" \
-              '{
-                channel: $channel,
-                ts: $ts,
-                text: ("GitHub Actions run " + ($status_label | ascii_downcase)),
-                attachments: [
-                  {
-                    color: (
-                      if ($status_label == "Succeeded") then "#2eb67d"
-                      elif ($status_label == "Failed") then "#e01e5a"
-                      elif ($status_label == "Cancelled") then "#9ca3af"
-                      else "#d4a017"
-                      end
-                    ),
-                    fields: [
-                      { title: "Status", value: $status_label, short: true },
-                      { title: "Commit", value: ($commit + " (" + $branch + ")"), short: true },
-                      if ($status_message != "") then { title: "Message", value: $status_message, short: false } else empty end,
-                      { title: "Workflow", value: ("<" + $run_url + "|" + $workflow + " / " + $job + ">"), short: false },
-                      { title: "Repository", value: $repo, short: false }
-                    ],
-                    footer: "GitHub Actions"
-                  }
-                ]
-              }')"
-            RESPONSE="$(curl -fsSL https://slack.com/api/chat.update \
-              -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
-              -H "Content-Type: application/json; charset=utf-8" \
-              --data "$PAYLOAD")"
-            OK="$(printf '%s' "$RESPONSE" | jq -r '.ok')"
-            if [ "$OK" != "true" ]; then
-              echo "Slack bot update failed, falling back to webhook: $RESPONSE"
-              send_webhook_fallback
-              exit 0
-            fi
+          if [ -z "${SLACK_BOT_TOKEN:-}" ] || [ -z "${MESSAGE_CHANNEL_ID:-}" ] || [ -z "${MESSAGE_TS:-}" ]; then
+            echo "No Slack bot update target available; skipping finish notification to avoid posting a duplicate standalone message."
             exit 0
           fi
 
-          send_webhook_fallback
+          PAYLOAD="$(jq -n \
+            --arg channel "$MESSAGE_CHANNEL_ID" \
+            --arg ts "$MESSAGE_TS" \
+            --arg workflow "$WORKFLOW_NAME" \
+            --arg job "$JOB_NAME" \
+            --arg branch "$REF_NAME" \
+            --arg commit "${SHA:0:7}" \
+            --arg repo "$REPOSITORY" \
+            --arg run_url "$RUN_URL" \
+            --arg status_label "$STATUS_LABEL" \
+            --arg status_message "$STATUS_MESSAGE" \
+            '{
+              channel: $channel,
+              ts: $ts,
+              text: ("GitHub Actions run " + ($status_label | ascii_downcase)),
+              attachments: [
+                {
+                  color: (
+                    if ($status_label == "Succeeded") then "#2eb67d"
+                    elif ($status_label == "Failed") then "#e01e5a"
+                    elif ($status_label == "Cancelled") then "#9ca3af"
+                    else "#d4a017"
+                    end
+                  ),
+                  fields: [
+                    { title: "Status", value: $status_label, short: true },
+                    { title: "Commit", value: ($commit + " (" + $branch + ")"), short: true },
+                    if ($status_message != "") then { title: "Message", value: $status_message, short: false } else empty end,
+                    { title: "Workflow", value: ("<" + $run_url + "|" + $workflow + " / " + $job + ">"), short: false },
+                    { title: "Repository", value: $repo, short: false }
+                  ],
+                  footer: "GitHub Actions"
+                }
+              ]
+            }')"
+          RESPONSE="$(curl -fsSL https://slack.com/api/chat.update \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$PAYLOAD")"
+          OK="$(printf '%s' "$RESPONSE" | jq -r '.ok')"
+          if [ "$OK" != "true" ]; then
+            echo "Slack bot update failed; skipping webhook fallback to avoid posting a duplicate standalone message: $RESPONSE"
+            exit 0
+          fi
 
   incidentio-notify-finish-failure:
     needs:

--- a/.github/workflows/synthetic-journeys.yml
+++ b/.github/workflows/synthetic-journeys.yml
@@ -49,7 +49,7 @@ jobs:
     needs:
       - slack-notify-start
       - synthetic-smoke
-    if: ${{ always() && needs.synthetic-smoke.result != 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.synthetic-smoke.result != 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish
@@ -73,7 +73,7 @@ jobs:
       - kill-switch-preflight
       - slack-notify-start
       - synthetic-smoke
-    if: ${{ always() && needs.kill-switch-preflight.outputs.active == 'true' && needs.synthetic-smoke.result == 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.kill-switch-preflight.outputs.active == 'true' && needs.synthetic-smoke.result == 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish

--- a/.github/workflows/vercel-analytics-report.yml
+++ b/.github/workflows/vercel-analytics-report.yml
@@ -64,7 +64,7 @@ jobs:
     needs:
       - slack-notify-start
       - analyze
-    if: ${{ always() && needs.analyze.result != 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.analyze.result != 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish
@@ -88,7 +88,7 @@ jobs:
       - kill-switch-preflight
       - slack-notify-start
       - analyze
-    if: ${{ always() && needs.kill-switch-preflight.outputs.active == 'true' && needs.analyze.result == 'skipped' }}
+    if: ${{ always() && needs.slack-notify-start.result == 'success' && needs.kill-switch-preflight.outputs.active == 'true' && needs.analyze.result == 'skipped' }}
     uses: ./.github/workflows/slack-notify-status.yml
     with:
       mode: finish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Changes are dated based on the default timezone: America/Los_Angeles
 
 ---
 
-### 6/20/2026 Development Update
+## 6/20/2026 Development Update
 
 - Completed routine dependency security cleanup.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
-Last updated (year-month-day): 2026-06-18
+Last updated (year-month-day): 2026-06-20
 
 This changelog summarizes notable ItemTraxx product, reliability, security, and experience updates.
 
 Changes are dated based on the default timezone: America/Los_Angeles
 
 ---
+
+### 6/20/2026 Development Update
+
+- Improved GitHub Actions Slack notification handling to prevent stray blank completion posts and preserve intentional maintenance-skip notices.
 
 ### 6/18/2026 Development Update
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changes are dated based on the default timezone: America/Los_Angeles
 
 ### 6/20/2026 Development Update
 
-- Improved GitHub Actions Slack notification handling to prevent stray blank completion posts and preserve intentional maintenance-skip notices.
+- Completed routine dependency security cleanup.
 
 ### 6/18/2026 Development Update
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       },
       "devDependencies": {
         "@cloudflare/vite-plugin": "^1.40.2",
-        "@cyclonedx/cyclonedx-npm": "4.2.1",
+        "@cyclonedx/cyclonedx-npm": "^5.0.0",
         "@playwright/test": "^1.61.0",
         "@types/node": "^25.9.3",
         "@vitejs/plugin-vue": "^6.0.7",
@@ -289,9 +289,9 @@
       }
     },
     "node_modules/@cyclonedx/cyclonedx-npm": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-npm/-/cyclonedx-npm-4.2.1.tgz",
-      "integrity": "sha512-SOA/96sf0wsgUYCRtFkLFm6WoFhG+q1BxdC84hPSn9J3xWlH1e7OnTPJT+WNUzTqzX1nSm5JhjRX4krozu2X+g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-npm/-/cyclonedx-npm-5.0.0.tgz",
+      "integrity": "sha512-pEz/pqYJHQ0ZvY5xFJa+GQ5AjNL7JOEJCXCHymvKo2N1VnzKE1ROpkumduJt8a0DukQjQfBGRXouGQ9xqJtJaQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.40.2",
-    "@cyclonedx/cyclonedx-npm": "4.2.1",
+    "@cyclonedx/cyclonedx-npm": "^5.0.0",
     "@playwright/test": "^1.61.0",
     "@types/node": "^25.9.3",
     "@vitejs/plugin-vue": "^6.0.7",


### PR DESCRIPTION
## Summary
Two CI/security fixes promoted from `dev/mmango10` to `preview`:

1. **Blank Slack posts** — GitHub Actions was posting blank/duplicate standalone
   messages in the git channel (observed June 18, 2026 ~10:41 PDT).
2. **High-severity npm audit finding** — shell-injection advisory in the SBOM
   generation tool.

## 1. Slack blank/duplicate posts
**Root cause:** `notify_finish` fell back to posting a *new standalone* message
(`send_webhook_fallback`) whenever it couldn't `chat.update` an existing threaded
message — e.g. finish-only calls firing while the kill switch was active.

**Fix:**
- `slack-notify-status.yml`: `notify_finish` now **only** updates the existing
  threaded message via `chat.update`. No bot token / channel / ts, or update
  failure → exit cleanly, post nothing. Removed both webhook fallbacks in finish.
- 10 caller workflows: finish jobs gated on
  `needs.slack-notify-start.result == 'success'` so finish only runs when a start
  message exists to update.
- `schedule-watchdog.yml`: the one legitimate finish-only notice (kill-switch
  skip) reimplemented as a guarded inline webhook post — guard moved into the run
  script (`secrets` context isn't available in a job-level `if`).
- `manage-kill-switch.yml`: added the same start-success gate for consistency.

## 2. npm audit — high (GHSA-v75r-vx73-82pj)
`@cyclonedx/cyclonedx-npm` shell injection via `--workspace`. Dev-only SBOM tool;
our `generate-sbom.sh` doesn't use `--workspace`, so no real exposure — but
clearing the alert:
- Bumped `4.2.1 → ^5.0.0` (node-compatible; SBOM specVersion now 1.6, artifact-only).
- Removed now-stale `ITX_AUDIT_ALLOW_SOURCES: "1121192"` from `security-audit.yml`
  so the audit gate is fully live again.

## Verification
- `npm audit`: **0 vulnerabilities**
- `npm run security:gate`: **passes** with empty allowlist
- `scripts/generate-sbom.sh`: valid CycloneDX 1.6 output (294 components)
- `npm run build` (vue-tsc + vite): **passes**
- All 16 workflow YAML files parse clean

## Risk
Low. CI/tooling only — no application runtime or source changes.