### PR TITLE
fix(legal): finalize DPA terms, refine legal pages & footer nav

### DIFF
--- a/DPA.md
+++ b/DPA.md
@@ -1,8 +1,6 @@
-# ItemTraxx Data Processing Addendum Template
+# ItemTraxx Data Processing Addendum
 
-Last updated: 2026-06-15 (year-month-day)
-
-**Status: Contract template requiring qualified legal review before execution.**
+Last updated: 2026-06-20 (year-month-day)
 
 This Data Processing Addendum ("DPA") supplements the applicable order form, subscription
 agreement, or other written agreement between ItemTraxx Co ("ItemTraxx") and the school, district,
@@ -37,16 +35,8 @@ confidentiality and any additional organizational commitments must be confirmed 
 
 ## 5. Service Providers
 
-Customer authorizes ItemTraxx to use subprocessors needed for hosting, database and authentication,
-storage, edge security, email, monitoring, diagnostics, support, and engineering operations.
-The current platform may use Supabase, Cloudflare, Vercel, PostHog, Sentry, transactional email
-providers, GitHub, Slack, and incident.io according to the active environment and feature
-configuration. ItemTraxx will provide at least thirty (30) days advance notice before adding or
-replacing a subprocessor that processes Customer Data, via email to the Customer's primary contact
-or a notice posted to the ItemTraxx legal hub. Customer may object in writing within that period;
-if the parties cannot resolve a reasonable objection, Customer may terminate the affected portion
-of the service on written notice. Any required subprocessor restrictions or additional flow-down
-terms must be included in the executed agreement.
+Customer authorizes ItemTraxx to use subprocessors needed for hosting, database and authentication, storage, edge security, email, monitoring, diagnostics, support, and engineering operations.
+The current platform may use Supabase, Cloudflare, Vercel, PostHog, Sentry, transactional email providers, GitHub, Slack, and incident.io according to the active environment and feature configuration. Any required subprocessor restrictions, approval rights, or additional flow-down terms must be included in the executed agreement.
 
 ## 6. Requests and Cooperation
 

--- a/DPA.md
+++ b/DPA.md
@@ -36,7 +36,8 @@ confidentiality and any additional organizational commitments must be confirmed 
 ## 5. Service Providers
 
 Customer authorizes ItemTraxx to use subprocessors needed for hosting, database and authentication, storage, edge security, email, monitoring, diagnostics, support, and engineering operations.
-The current platform may use Supabase, Cloudflare, Vercel, PostHog, Sentry, transactional email providers, GitHub, Slack, and incident.io according to the active environment and feature configuration. Any required subprocessor restrictions, approval rights, or additional flow-down terms must be included in the executed agreement.
+The current platform may use Supabase, Cloudflare, Vercel, PostHog, Sentry, transactional email providers, GitHub, Slack, and incident.io according to the active environment and feature configuration.
+This DPA does not create a general third-party subprocessor-change notice, objection, or termination right unless those rights are expressly included in the executed agreement. Any required subprocessor restrictions, approval rights, notice obligations, objection rights, termination rights, or additional flow-down terms must be included in the executed agreement.
 
 ## 6. Requests and Cooperation
 

--- a/src/components/PublicFooter.vue
+++ b/src/components/PublicFooter.vue
@@ -40,17 +40,22 @@
         <a href="https://status.itemtraxx.com/" target="_blank" rel="noreferrer">Status</a>
       </div>
       <div class="footer-column">
-        <p class="footer-heading">Company</p>
-        <RouterLink to="/">Home</RouterLink>
-        <RouterLink to="/contact">Contact</RouterLink>
-        <RouterLink to="/compliance">Compliance</RouterLink>
-        <RouterLink to="/legal">Legal</RouterLink>
+        <p class="footer-heading">Legal</p>
+        <RouterLink to="/legal">Legal Home</RouterLink>
         <RouterLink to="/privacy">Privacy</RouterLink>
         <RouterLink to="/legal/student-privacy">Student Privacy</RouterLink>
         <RouterLink to="/legal/dpa">Data Processing Addendum</RouterLink>
         <RouterLink to="/privacy-request">Privacy Request</RouterLink>
         <RouterLink to="/cookies">Cookies</RouterLink>
         <RouterLink to="/accessibility">Accessibility</RouterLink>
+        <RouterLink to="/security">Security</RouterLink>
+        <RouterLink to="/trust">Trust</RouterLink>
+        <RouterLink to="/compliance">Compliance</RouterLink>
+      </div>
+      <div class="footer-column">
+        <p class="footer-heading">Company</p>
+        <RouterLink to="/">Home</RouterLink>
+        <RouterLink to="/contact">Contact</RouterLink>
         <RouterLink to="/about">About</RouterLink>
         <a href="https://github.com/ItemTraxxCo" target="_blank" rel="noreferrer">GitHub</a>
       </div>
@@ -148,7 +153,7 @@ onUnmounted(() => {
 
 .footer-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 1.5rem 2.5rem;
   flex: 1;
 }

--- a/src/components/PublicFooter.vue
+++ b/src/components/PublicFooter.vue
@@ -32,9 +32,7 @@
       <div class="footer-column">
         <p class="footer-heading">Support</p>
         <RouterLink to="/contact-support">Contact Support</RouterLink>
-        <RouterLink to="/security">Security</RouterLink>
         <RouterLink to="/report-security-issue">Report Security Issue</RouterLink>
-        <RouterLink to="/trust">Trust</RouterLink>
         <RouterLink to="/changelog">Changelog</RouterLink>
         <RouterLink to="/faq">FAQ</RouterLink>
         <a href="https://status.itemtraxx.com/" target="_blank" rel="noreferrer">Status</a>

--- a/src/pages/LegalDocumentPage.vue
+++ b/src/pages/LegalDocumentPage.vue
@@ -42,6 +42,17 @@ const sections = computed<Section[]>(() => {
   const result: Section[] = [];
   let current: Section | null = null;
   let pendingList: string[] = [];
+  let pendingParagraph: string[] = [];
+
+  const flushParagraph = () => {
+    if (!current || !pendingParagraph.length) return;
+    current.blocks.push({
+      type: "paragraph",
+      text: pendingParagraph.join(" ").replace(/\*\*/g, ""),
+    });
+    pendingParagraph = [];
+  };
+
   const flushList = () => {
     if (current && pendingList.length) current.blocks.push({ type: "list", items: [...pendingList] });
     pendingList = [];
@@ -50,23 +61,29 @@ const sections = computed<Section[]>(() => {
   for (const raw of lines.value) {
     const line = raw.trim();
     if (!line || line === "---") {
+      flushParagraph();
       flushList();
       continue;
     }
     if (line.startsWith("# ") || line.startsWith("Last updated:")) continue;
     if (line.startsWith("## ")) {
+      flushParagraph();
       flushList();
       if (current) result.push(current);
       current = { title: line.slice(3).trim(), blocks: [] };
       continue;
     }
     if (!current) current = { title: "Overview", blocks: [] };
-    if (line.startsWith("- ")) pendingList.push(line.slice(2).trim());
+    if (line.startsWith("- ")) {
+      flushParagraph();
+      pendingList.push(line.slice(2).trim());
+    }
     else {
       flushList();
-      current.blocks.push({ type: "paragraph", text: line.replace(/\*\*/g, "") });
+      pendingParagraph.push(line);
     }
   }
+  flushParagraph();
   flushList();
   if (current) result.push(current);
   return result;

--- a/src/pages/PrivacyPage.vue
+++ b/src/pages/PrivacyPage.vue
@@ -142,6 +142,13 @@ const sections = computed<PrivacySection[]>(() => {
   const result: PrivacySection[] = [];
   let current: PrivacySection | null = null;
   let pendingList: string[] = [];
+  let pendingParagraph: string[] = [];
+
+  const flushParagraph = () => {
+    if (!current || !pendingParagraph.length) return;
+    current.blocks.push({ type: "paragraph", text: pendingParagraph.join(" ") });
+    pendingParagraph = [];
+  };
 
   const flushList = () => {
     if (current && pendingList.length) {
@@ -153,11 +160,13 @@ const sections = computed<PrivacySection[]>(() => {
   for (const rawLine of lines) {
     const line = rawLine.trim();
     if (!line || line === '---') {
+      flushParagraph();
       flushList();
       continue;
     }
     if (line.startsWith('# ') || line.startsWith('Last updated:')) continue;
     if (line.startsWith('## ')) {
+      flushParagraph();
       flushList();
       if (current) result.push(current);
       current = { title: line.replace(/^##\s+/, '').trim(), blocks: [] };
@@ -165,13 +174,15 @@ const sections = computed<PrivacySection[]>(() => {
     }
     if (!current) continue;
     if (line.startsWith('- ')) {
+      flushParagraph();
       pendingList.push(line.replace(/^-\s+/, '').trim());
       continue;
     }
     flushList();
-    current.blocks.push({ type: 'paragraph', text: line });
+    pendingParagraph.push(line);
   }
 
+  flushParagraph();
   flushList();
   if (current) result.push(current);
   return result;

--- a/src/pages/PublicHome.vue
+++ b/src/pages/PublicHome.vue
@@ -265,10 +265,19 @@
           </a>
         </div>
         <div class="footer-column">
-          <p class="footer-heading">Company</p>
-          <RouterLink to="/legal">Legal</RouterLink>
+          <p class="footer-heading">Legal</p>
+          <RouterLink to="/legal">Legal Home</RouterLink>
           <RouterLink to="/privacy">Privacy</RouterLink>
-        <RouterLink to="/accessibility">Accessibility</RouterLink>
+          <RouterLink to="/legal/student-privacy">Student Privacy</RouterLink>
+          <RouterLink to="/legal/dpa">DPA</RouterLink>
+          <RouterLink to="/cookies">Cookies</RouterLink>
+          <RouterLink to="/accessibility">Accessibility</RouterLink>
+          <RouterLink to="/security">Security</RouterLink>
+          <RouterLink to="/trust">Trust</RouterLink>
+          <RouterLink to="/compliance">Compliance</RouterLink>
+        </div>
+        <div class="footer-column">
+          <p class="footer-heading">Company</p>
           <RouterLink to="/about">About</RouterLink>
         </div>
       </div>

--- a/src/pages/PublicHome.vue
+++ b/src/pages/PublicHome.vue
@@ -269,7 +269,7 @@
           <RouterLink to="/legal">Legal Home</RouterLink>
           <RouterLink to="/privacy">Privacy</RouterLink>
           <RouterLink to="/legal/student-privacy">Student Privacy</RouterLink>
-          <RouterLink to="/legal/dpa">DPA</RouterLink>
+          <RouterLink to="/legal/dpa">Data Processing Addendum</RouterLink>
           <RouterLink to="/cookies">Cookies</RouterLink>
           <RouterLink to="/accessibility">Accessibility</RouterLink>
           <RouterLink to="/security">Security</RouterLink>

--- a/supabase/functions/_shared/subprocessorNotice.ts
+++ b/supabase/functions/_shared/subprocessorNotice.ts
@@ -123,8 +123,7 @@ export function buildSubprocessorNoticeHtml(
                 <tr>
                   <td style="padding:0 0 20px;font-size:15px;color:#444444;line-height:1.6;">
                     You are receiving this notice because your organization has an active ItemTraxx service
-                    agreement that includes a Data Processing Addendum. Under that agreement, ItemTraxx is
-                    required to notify you at least 30 days before adding or replacing a subprocessor.
+                    agreement that requires notice for this subprocessor change.
                   </td>
                 </tr>
                 <tr>
@@ -156,11 +155,11 @@ export function buildSubprocessorNoticeHtml(
                 </tr>
                 <tr>
                   <td style="padding:0 0 20px;font-size:15px;color:#444444;line-height:1.6;">
-                    Under your Data Processing Addendum, you may object to this change in writing before
-                    the effective date (<strong>${
+                    If your executed agreement includes objection or approval rights for this change, please
+                    contact us in writing before the effective date (<strong>${
     escapeHtml(effectiveDateLabel)
   }</strong>). If you have
-                    questions, wish to object, or need a copy of the updated DPA, please contact us.
+                    questions or need a copy of the current DPA, please contact us.
                   </td>
                 </tr>
                 <tr>
@@ -188,7 +187,7 @@ export function buildSubprocessorNoticeHtml(
           </tr>
           <tr>
             <td style="padding:18px 32px;border-top:1px solid #e5e5e5;font-size:12px;color:#888888;line-height:1.5;">
-              This is a required legal notice sent to customers with an active Data Processing Addendum.
+              This notice is sent to customers whose executed agreement requires subprocessor-change notice.
               ItemTraxx Co &middot; 670 San Antonio Rd, Palo Alto, CA 94306, USA &middot; support@itemtraxx.com
             </td>
           </tr>
@@ -214,8 +213,7 @@ export function buildSubprocessorNoticePlainText(
   }
 
 You are receiving this notice because your organization has an active ItemTraxx service agreement
-that includes a Data Processing Addendum. Under that agreement, ItemTraxx is required to notify
-you at least 30 days before adding or replacing a subprocessor.
+that requires notice for this subprocessor change.
 
 CHANGE DETAILS
 --------------
@@ -223,17 +221,17 @@ Subprocessor: ${p.vendor}
 Change: ${p.vendor} ${changeTypeLabel(p.changeType)}
 Effective date: ${effectiveDateLabel}
 ${descriptionLine}
-YOUR RIGHTS
------------
-Under your Data Processing Addendum, you may object to this change in writing before the effective
-date (${effectiveDateLabel}). If you have questions, wish to object, or need a copy of the updated
-DPA, please contact us before that date.
+CONTRACT TERMS
+--------------
+If your executed agreement includes objection or approval rights for this change, please contact us
+in writing before the effective date (${effectiveDateLabel}). If you have questions or need a copy
+of the current DPA, please contact us before that date.
 
 Contact Support: ${contactSupportUrl}
 View DPA & Legal Docs: ${legalHubUrl}
 
 ---
-This is a required legal notice sent to customers with an active Data Processing Addendum.
+This notice is sent to customers whose executed agreement requires subprocessor-change notice.
 ItemTraxx Co · 670 San Antonio Rd, Palo Alto, CA 94306, USA · support@itemtraxx.com
 `;
 }

--- a/supabase/functions/_shared/subprocessorNotice_test.ts
+++ b/supabase/functions/_shared/subprocessorNotice_test.ts
@@ -171,10 +171,10 @@ Deno.test("buildSubprocessorNoticePlainText: omits description line when absent"
   assertEquals(text.includes("Details:"), false);
 });
 
-Deno.test("buildSubprocessorNoticePlainText: objection rights section present", () => {
+Deno.test("buildSubprocessorNoticePlainText: contract terms section present", () => {
   const text = buildSubprocessorNoticePlainText(BASE);
-  assertStringIncludes(text, "YOUR RIGHTS");
-  assertStringIncludes(text, "object to this change in writing");
+  assertStringIncludes(text, "CONTRACT TERMS");
+  assertStringIncludes(text, "If your executed agreement includes objection or approval rights");
 });
 
 // --- preview ---

--- a/tests/e2e/privacy-compliance.spec.ts
+++ b/tests/e2e/privacy-compliance.spec.ts
@@ -76,7 +76,7 @@ test.describe("Privacy and legal controls", () => {
     await expect(page.getByRole("heading", { name: "Student Privacy Notice", level: 1 })).toBeVisible();
 
     await page.goto("/legal/dpa");
-    await expect(page.getByRole("heading", { name: "ItemTraxx Data Processing Addendum Template", level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "ItemTraxx Data Processing Addendum", level: 1 })).toBeVisible();
   });
 
 });


### PR DESCRIPTION
## Summary
Promotes legal-content and public-page UI fixes from `dev/mmango10` to `preview`.

## Changes
**DPA (`DPA.md`)**
- Drop "Template" / "requiring qualified legal review" framing — now an executable DPA. Bumped Last updated to 2026-06-20.
- Reworked §5 Service Providers: removed the standalone 30-day subprocessor-change notice / objection / termination right; clarifies those rights apply only if expressly in the executed agreement.

**Legal / public pages**
- `LegalDocumentPage.vue`, `PrivacyPage.vue`, `PublicHome.vue`: layout refinements.
- `PublicFooter.vue`: footer navigation refinements.

**Subprocessor notice**
- `_shared/subprocessorNotice.ts` + `_shared/subprocessorNotice_test.ts`: align notice copy with new DPA §5; tests updated.
- `tests/e2e/privacy-compliance.spec.ts`: assertion update.

## Risk
Low. Legal copy + presentational UI + matching test updates. No runtime/auth/data-path logic changed.

## Verification
- Subprocessor unit tests + privacy-compliance e2e updated to match.