### PR TITLE
perf(barcode): vectorize label PDF and optimize camera scanner

### DIFF
--- a/src/composables/useCameraBarcodeScanner.ts
+++ b/src/composables/useCameraBarcodeScanner.ts
@@ -93,6 +93,24 @@ const getTorchSupport = (track: MediaStreamTrack | null) => {
   return Boolean(capabilities.torch);
 };
 
+const applyContinuousFocus = async (track: MediaStreamTrack | null) => {
+  if (!track || typeof (track as MediaStreamTrack & { getCapabilities?: () => MediaTrackCapabilities }).getCapabilities !== "function") {
+    return;
+  }
+  try {
+    const capabilities = (track as MediaStreamTrack & {
+      getCapabilities: () => MediaTrackCapabilities;
+    }).getCapabilities() as MediaTrackCapabilities & { focusMode?: string[] };
+    if (Array.isArray(capabilities.focusMode) && capabilities.focusMode.includes("continuous")) {
+      await track.applyConstraints({
+        advanced: [{ focusMode: "continuous" } as unknown as MediaTrackConstraintSet],
+      });
+    }
+  } catch {
+    // Focus control unsupported on this device/browser; rely on system default.
+  }
+};
+
 const chooseStatus = (metrics: FrameMetrics, hasDetection: boolean): ScannerStatus => {
   if (metrics.brightness < 20) return "low_light";
   if (metrics.glareRatio > 0.26) return "glare";
@@ -127,8 +145,12 @@ export const useCameraBarcodeScanner = (options: UseCameraBarcodeScannerOptions)
   let scanTimer: number | null = null;
   let devices: string[] = [];
   let deviceIndex = 0;
-  let canvas: HTMLCanvasElement | null = null;
-  let context: CanvasRenderingContext2D | null = null;
+  let metricsCanvas: HTMLCanvasElement | null = null;
+  let metricsContext: CanvasRenderingContext2D | null = null;
+  let detectCanvas: HTMLCanvasElement | null = null;
+  let detectContext: CanvasRenderingContext2D | null = null;
+  let scanInFlight = false;
+  let loopActive = false;
   let lastScanValue = "";
   let lastScanAt = 0;
   let lastStatusKey = "";
@@ -158,8 +180,9 @@ export const useCameraBarcodeScanner = (options: UseCameraBarcodeScannerOptions)
   };
 
   const stopLoop = () => {
+    loopActive = false;
     if (scanTimer !== null) {
-      window.clearInterval(scanTimer);
+      window.clearTimeout(scanTimer);
       scanTimer = null;
     }
   };
@@ -187,13 +210,13 @@ export const useCameraBarcodeScanner = (options: UseCameraBarcodeScannerOptions)
 
   const analyzeFrame = (): FrameMetrics => {
     const video = videoRef.value;
-    if (!video || !context || !canvas) return { brightness: 0, glareRatio: 0, sharpness: 0 };
+    if (!video || !metricsContext || !metricsCanvas) return { brightness: 0, glareRatio: 0, sharpness: 0 };
     const width = 240;
     const height = 180;
-    canvas.width = width;
-    canvas.height = height;
-    context.drawImage(video, 0, 0, width, height);
-    const { data } = context.getImageData(0, 0, width, height);
+    if (metricsCanvas.width !== width) metricsCanvas.width = width;
+    if (metricsCanvas.height !== height) metricsCanvas.height = height;
+    metricsContext.drawImage(video, 0, 0, width, height);
+    const { data } = metricsContext.getImageData(0, 0, width, height);
     let brightnessTotal = 0;
     let glareCount = 0;
     let sharpnessTotal = 0;
@@ -225,7 +248,7 @@ export const useCameraBarcodeScanner = (options: UseCameraBarcodeScannerOptions)
   };
 
   const detectInCenterRegion = async (video: HTMLVideoElement): Promise<DetectedBarcodeLike | null> => {
-    if (!detector || !canvas || !context || !video.videoWidth || !video.videoHeight) return null;
+    if (!detector || !detectCanvas || !detectContext || !video.videoWidth || !video.videoHeight) return null;
     const sourceWidth = video.videoWidth;
     const sourceHeight = video.videoHeight;
     const region = {
@@ -235,9 +258,11 @@ export const useCameraBarcodeScanner = (options: UseCameraBarcodeScannerOptions)
       y: sourceHeight * 0.31,
     };
 
-    canvas.width = Math.max(1, Math.round(region.width * 1.4));
-    canvas.height = Math.max(1, Math.round(region.height * 1.4));
-    context.drawImage(
+    const targetWidth = Math.max(1, Math.round(region.width * 1.4));
+    const targetHeight = Math.max(1, Math.round(region.height * 1.4));
+    if (detectCanvas.width !== targetWidth) detectCanvas.width = targetWidth;
+    if (detectCanvas.height !== targetHeight) detectCanvas.height = targetHeight;
+    detectContext.drawImage(
       video,
       region.x,
       region.y,
@@ -245,19 +270,19 @@ export const useCameraBarcodeScanner = (options: UseCameraBarcodeScannerOptions)
       region.height,
       0,
       0,
-      canvas.width,
-      canvas.height
+      detectCanvas.width,
+      detectCanvas.height
     );
 
-    const matches = await detector.detect(canvas);
+    const matches = await detector.detect(detectCanvas);
     const firstMatch = matches.find((item) => Boolean(item.rawValue?.trim()));
     if (!firstMatch) return null;
 
     const box = toBoundingBox(firstMatch.boundingBox);
     if (!box) return firstMatch;
 
-    const scaleX = region.width / canvas.width;
-    const scaleY = region.height / canvas.height;
+    const scaleX = region.width / detectCanvas.width;
+    const scaleY = region.height / detectCanvas.height;
     return {
       ...firstMatch,
       boundingBox: {
@@ -325,6 +350,8 @@ export const useCameraBarcodeScanner = (options: UseCameraBarcodeScannerOptions)
   const scanFrame = async () => {
     const video = videoRef.value;
     if (!video || !detector || video.readyState < 2) return;
+    if (scanInFlight) return;
+    scanInFlight = true;
 
     const metrics = analyzeFrame();
     try {
@@ -376,13 +403,24 @@ export const useCameraBarcodeScanner = (options: UseCameraBarcodeScannerOptions)
       currentDetection.value = null;
       previewBox.value = null;
       emitStatus("unscannable");
+    } finally {
+      scanInFlight = false;
     }
   };
 
   const startLoop = () => {
     stopLoop();
-    scanTimer = window.setInterval(() => {
-      void scanFrame();
+    loopActive = true;
+    const tick = async () => {
+      if (!loopActive) return;
+      await scanFrame();
+      if (!loopActive) return;
+      scanTimer = window.setTimeout(() => {
+        void tick();
+      }, SCAN_INTERVAL_MS);
+    };
+    scanTimer = window.setTimeout(() => {
+      void tick();
     }, SCAN_INTERVAL_MS);
   };
 
@@ -427,13 +465,34 @@ export const useCameraBarcodeScanner = (options: UseCameraBarcodeScannerOptions)
     try {
       stopStream();
       detector = new DetectorCtor({ formats: [...FORMATS] });
+      const baseVideo: MediaTrackConstraints = {
+        width: { ideal: 1920 },
+        height: { ideal: 1080 },
+        frameRate: { ideal: 30 },
+      };
       const constraints: MediaStreamConstraints = {
         video: devices[deviceIndex]
-          ? { deviceId: { exact: devices[deviceIndex] } }
-          : { facingMode: usingRearCamera.value ? { ideal: "environment" } : { ideal: "user" } },
+          ? { ...baseVideo, deviceId: { exact: devices[deviceIndex] } }
+          : {
+              ...baseVideo,
+              facingMode: usingRearCamera.value ? { ideal: "environment" } : { ideal: "user" },
+            },
         audio: false,
       };
-      stream = await navigator.mediaDevices.getUserMedia(constraints);
+      // Minimal constraints used as a fallback when the preferred ones are
+      // rejected (e.g. a stale exact deviceId or an unsupported resolution),
+      // so the scanner degrades to the default camera instead of failing.
+      const fallbackConstraints: MediaStreamConstraints = {
+        video: {
+          facingMode: usingRearCamera.value ? { ideal: "environment" } : { ideal: "user" },
+        },
+        audio: false,
+      };
+      try {
+        stream = await navigator.mediaDevices.getUserMedia(constraints);
+      } catch {
+        stream = await navigator.mediaDevices.getUserMedia(fallbackConstraints);
+      }
       currentTrack = stream.getVideoTracks()[0] ?? null;
       if (!currentTrack) {
         throw new Error("No camera track available.");
@@ -442,6 +501,7 @@ export const useCameraBarcodeScanner = (options: UseCameraBarcodeScannerOptions)
         videoRef.value.srcObject = stream;
         await videoRef.value.play();
       }
+      await applyContinuousFocus(currentTrack);
       await refreshCapabilities();
       startLoop();
     } catch (error) {
@@ -500,13 +560,30 @@ export const useCameraBarcodeScanner = (options: UseCameraBarcodeScannerOptions)
     );
   };
 
+  const handleVisibilityChange = () => {
+    if (typeof document === "undefined") return;
+    if (document.hidden) {
+      // Pause the scan loop while backgrounded to save CPU/battery; the camera
+      // stream is left intact so resuming is instant.
+      stopLoop();
+    } else if (isOpen.value && stream && detector) {
+      startLoop();
+    }
+  };
+
   onUnmounted(() => {
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    }
     stopStream();
   });
 
   if (typeof document !== "undefined") {
-    canvas = document.createElement("canvas");
-    context = canvas.getContext("2d", { willReadFrequently: true });
+    metricsCanvas = document.createElement("canvas");
+    metricsContext = metricsCanvas.getContext("2d", { willReadFrequently: true });
+    detectCanvas = document.createElement("canvas");
+    detectContext = detectCanvas.getContext("2d", { willReadFrequently: true });
+    document.addEventListener("visibilitychange", handleVisibilityChange);
   }
 
   return {

--- a/src/composables/useCameraBarcodeScanner.ts
+++ b/src/composables/useCameraBarcodeScanner.ts
@@ -357,8 +357,8 @@ export const useCameraBarcodeScanner = (options: UseCameraBarcodeScannerOptions)
     if (scanInFlight) return;
     scanInFlight = true;
 
-    const metrics = analyzeFrame();
     try {
+      const metrics = analyzeFrame();
       const matches = await detector.detect(video);
       let firstMatch = matches.find((item) => Boolean(item.rawValue?.trim())) ?? null;
       if (!firstMatch) {
@@ -509,7 +509,11 @@ export const useCameraBarcodeScanner = (options: UseCameraBarcodeScannerOptions)
       }
       await applyContinuousFocus(currentTrack);
       await refreshCapabilities();
-      startLoop();
+      // Skip starting the loop if the tab went hidden during async startup;
+      // the visibilitychange handler resumes scanning on foreground.
+      if (typeof document === "undefined" || !document.hidden) {
+        startLoop();
+      }
     } catch (error) {
       permissionDenied.value = true;
       errorMessage.value =

--- a/src/composables/useCameraBarcodeScanner.ts
+++ b/src/composables/useCameraBarcodeScanner.ts
@@ -151,6 +151,7 @@ export const useCameraBarcodeScanner = (options: UseCameraBarcodeScannerOptions)
   let detectContext: CanvasRenderingContext2D | null = null;
   let scanInFlight = false;
   let loopActive = false;
+  let loopGeneration = 0;
   let lastScanValue = "";
   let lastScanAt = 0;
   let lastStatusKey = "";
@@ -181,6 +182,9 @@ export const useCameraBarcodeScanner = (options: UseCameraBarcodeScannerOptions)
 
   const stopLoop = () => {
     loopActive = false;
+    // Invalidate any in-flight tick closure so a resuming scanFrame cannot
+    // schedule another timer after the loop has been stopped/restarted.
+    loopGeneration += 1;
     if (scanTimer !== null) {
       window.clearTimeout(scanTimer);
       scanTimer = null;
@@ -411,10 +415,12 @@ export const useCameraBarcodeScanner = (options: UseCameraBarcodeScannerOptions)
   const startLoop = () => {
     stopLoop();
     loopActive = true;
+    const generation = loopGeneration;
+    const isCurrent = () => loopActive && generation === loopGeneration;
     const tick = async () => {
-      if (!loopActive) return;
+      if (!isCurrent()) return;
       await scanFrame();
-      if (!loopActive) return;
+      if (!isCurrent()) return;
       scanTimer = window.setTimeout(() => {
         void tick();
       }, SCAN_INTERVAL_MS);

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,9 @@ declare global {
       }) => Promise<unknown>;
       clearSession: () => void;
       navigate: (path: string) => Promise<void>;
+      generateBarcodePattern: (
+        value: string
+      ) => Promise<{ modules: number; bars: { start: number; width: number }[] }>;
     };
   }
 }
@@ -159,6 +162,20 @@ const attachE2EControls = () => {
     },
     async navigate(path: string) {
       await router.push(path);
+    },
+    async generateBarcodePattern(value: string) {
+      const [{ createBarcodePattern }, { default: JsBarcode }] = await Promise.all([
+        import("./services/barcodePdfService"),
+        import("jsbarcode"),
+      ]);
+      return createBarcodePattern(
+        value,
+        JsBarcode as (
+          element: HTMLCanvasElement,
+          text: string,
+          options?: unknown
+        ) => void
+      );
     },
   };
 };

--- a/src/services/barcodePdfService.ts
+++ b/src/services/barcodePdfService.ts
@@ -1,6 +1,6 @@
-type BarRun = { start: number; width: number };
+export type BarRun = { start: number; width: number };
 
-type BarcodePattern = { modules: number; bars: BarRun[] };
+export type BarcodePattern = { modules: number; bars: BarRun[] };
 
 // Use JsBarcode purely as the (scanner-correct) CODE128 encoder, then read a
 // single pixel row to recover the bar pattern. Rendering one module-wide,
@@ -23,7 +23,7 @@ export const createBarcodePattern = (
   });
 
   const context = canvas.getContext("2d");
-  if (!context || canvas.width === 0) {
+  if (!context || canvas.width === 0 || canvas.height === 0) {
     throw new Error("Unable to render barcode.");
   }
 

--- a/src/services/barcodePdfService.ts
+++ b/src/services/barcodePdfService.ts
@@ -1,18 +1,53 @@
-const createBarcodeCanvas = (
+type BarRun = { start: number; width: number };
+
+type BarcodePattern = { modules: number; bars: BarRun[] };
+
+// Use JsBarcode purely as the (scanner-correct) CODE128 encoder, then read a
+// single pixel row to recover the bar pattern. Rendering one module-wide,
+// zero-margin barcode makes canvas.width equal the module count, so we can
+// draw the bars as crisp vector rectangles in the PDF instead of embedding a
+// rasterised PNG.
+export const createBarcodePattern = (
   value: string,
   JsBarcode: (element: HTMLCanvasElement, text: string, options?: unknown) => void
-) => {
+): BarcodePattern => {
   const canvas = document.createElement("canvas");
   JsBarcode(canvas, value, {
     format: "CODE128",
     displayValue: false,
-    margin: 2,
-    width: 1.2,
-    height: 34,
+    margin: 0,
+    width: 1,
+    height: 1,
     background: "#ffffff",
     lineColor: "#000000",
   });
-  return canvas;
+
+  const context = canvas.getContext("2d");
+  if (!context || canvas.width === 0) {
+    throw new Error("Unable to render barcode.");
+  }
+
+  const row = Math.floor(canvas.height / 2);
+  const { data } = context.getImageData(0, row, canvas.width, 1);
+
+  const bars: BarRun[] = [];
+  let runStart = -1;
+  for (let column = 0; column < canvas.width; column += 1) {
+    const offset = column * 4;
+    // Treat a pixel as part of a bar when it is dark and opaque.
+    const isDark = data[offset + 3] > 0 && data[offset] < 128;
+    if (isDark && runStart === -1) {
+      runStart = column;
+    } else if (!isDark && runStart !== -1) {
+      bars.push({ start: runStart, width: column - runStart });
+      runStart = -1;
+    }
+  }
+  if (runStart !== -1) {
+    bars.push({ start: runStart, width: canvas.width - runStart });
+  }
+
+  return { modules: canvas.width, bars };
 };
 
 export const downloadBarcodePdf = async (barcodes: string[], message: string) => {
@@ -58,21 +93,25 @@ export const downloadBarcodePdf = async (barcodes: string[], message: string) =>
     pdf.setFontSize(8.5);
     pdf.text(barcode, x + labelWidth / 2, y + 14, { align: "center" });
 
-    const canvas = createBarcodeCanvas(
+    const pattern = createBarcodePattern(
       barcode,
       JsBarcode as (element: HTMLCanvasElement, text: string, options?: unknown) => void
     );
     const barcodeWidth = Math.min(targetBarcodeWidth, labelWidth - 14);
     const barcodeHeight = targetBarcodeHeight;
     const barcodeX = x + (labelWidth - barcodeWidth) / 2;
-    pdf.addImage(
-      canvas.toDataURL("image/png"),
-      "PNG",
-      barcodeX,
-      y + 18,
-      barcodeWidth,
-      barcodeHeight
-    );
+    const barcodeY = y + 18;
+    const moduleWidth = barcodeWidth / pattern.modules;
+    pdf.setFillColor(0, 0, 0);
+    for (const bar of pattern.bars) {
+      pdf.rect(
+        barcodeX + bar.start * moduleWidth,
+        barcodeY,
+        bar.width * moduleWidth,
+        barcodeHeight,
+        "F"
+      );
+    }
 
     if (message.trim()) {
       pdf.setFont("helvetica", "normal");

--- a/tests/e2e/barcode-pattern.spec.ts
+++ b/tests/e2e/barcode-pattern.spec.ts
@@ -1,10 +1,6 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
-
-type BarcodePattern = {
-  modules: number;
-  bars: { start: number; width: number }[];
-};
+import type { BarcodePattern } from "../../src/services/barcodePdfService";
 
 const generatePattern = async (page: Page, value: string): Promise<BarcodePattern> => {
   await page.waitForFunction(

--- a/tests/e2e/barcode-pattern.spec.ts
+++ b/tests/e2e/barcode-pattern.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+type BarcodePattern = {
+  modules: number;
+  bars: { start: number; width: number }[];
+};
+
+const generatePattern = async (page: Page, value: string): Promise<BarcodePattern> => {
+  await page.waitForFunction(
+    () => typeof window.__itemtraxxTest?.generateBarcodePattern === "function"
+  );
+  return page.evaluate(
+    (input) => window.__itemtraxxTest!.generateBarcodePattern(input),
+    value
+  );
+};
+
+test.describe("createBarcodePattern", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+  });
+
+  test("produces vector bars for a typical barcode", async ({ page }) => {
+    const pattern = await generatePattern(page, "ITX-12345");
+
+    expect(pattern.modules).toBeGreaterThan(0);
+    expect(pattern.bars.length).toBeGreaterThan(0);
+
+    // CODE128 always opens with a bar (the start quiet zone is stripped because
+    // we render with margin: 0), so the first run must begin at module 0.
+    expect(pattern.bars[0].start).toBe(0);
+
+    // Every run must be a positive-width slice that stays inside the module grid.
+    for (const bar of pattern.bars) {
+      expect(bar.width).toBeGreaterThan(0);
+      expect(bar.start).toBeGreaterThanOrEqual(0);
+      expect(bar.start + bar.width).toBeLessThanOrEqual(pattern.modules);
+    }
+
+    // Runs must be ordered and non-overlapping.
+    for (let i = 1; i < pattern.bars.length; i += 1) {
+      const prev = pattern.bars[i - 1];
+      expect(pattern.bars[i].start).toBeGreaterThanOrEqual(prev.start + prev.width);
+    }
+  });
+
+  test("is deterministic for the same value", async ({ page }) => {
+    const first = await generatePattern(page, "ABC-987");
+    const second = await generatePattern(page, "ABC-987");
+    expect(second).toEqual(first);
+  });
+
+  test("encodes different values differently", async ({ page }) => {
+    const a = await generatePattern(page, "AAAA0001");
+    const b = await generatePattern(page, "ZZZZ9999");
+    expect(JSON.stringify(a)).not.toBe(JSON.stringify(b));
+  });
+});


### PR DESCRIPTION
Barcode label PDF (barcodePdfService):
- Replace canvas→PNG→addImage with vector CODE128 bars drawn via
  pdf.rect(). JsBarcode still encodes (scanner-correct); we read one
  pixel row to recover the module pattern. Sharper print, smaller
  PDF, no per-label PNG raster/encode.
- Export createBarcodePattern + expose a test-only
  generateBarcodePattern helper on window.__itemtraxxTest.

Camera scanner (useCameraBarcodeScanner):
- Add in-flight guard and switch the scan loop from setInterval to a
  self-rescheduling setTimeout so slow detect() calls can't pile up.
- Split the shared canvas into dedicated metrics/detect canvases to
  stop per-frame resize/realloc thrash.
- Pause the scan loop on visibilitychange (tab hidden) to save
  CPU/battery; stream is kept for instant resume.
- Request higher capture resolution (ideal 1920x1080@30) and enable
  continuous autofocus, both feature-detected/graceful.
- Retry getUserMedia with minimal constraints when the preferred
  ones are rejected (stale exact deviceId / unsupported resolution),
  degrading to the default camera instead of manual entry.

Tests:
- Add tests/e2e/barcode-pattern.spec.ts covering createBarcodePattern
  (valid bounded pattern, determinism, distinct values).

Full e2e suite green (31 passed).