### PR TITLE
update gitattrubutes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.ts linguist-language=Vue
+*.tsx linguist-language=Vue
+*.d.ts linguist-language=Vue


### PR DESCRIPTION
This PR adds a `.gitattributes` Linguist override so GitHub classifies TypeScript-family files as Vue for repository language statistics.

**Changes**

- Counts `*.ts`, `*.tsx`, and `*.d.ts` files as `Vue` in GitHub Linguist
- Leaves source code, build behavior, and runtime behavior unchanged
- Keeps the repo language display aligned with the app’s Vue frontend identity

**Validation**

- Verified the repo is clean after commit
- Confirmed the latest commit only adds `.gitattributes` with the Linguist overrides