### PR TITLE
Add PR Gaurds

### DIFF
--- a/.github/workflows/guard-dev-prs-to-main.yml
+++ b/.github/workflows/guard-dev-prs-to-main.yml
@@ -3,7 +3,6 @@ name: Guard Dev PRs To Main
 permissions:
   contents: read
   issues: write
-  pull-requests: write
 
 on:
   pull_request:
@@ -38,7 +37,7 @@ jobs:
 
       - name: Comment on blocked PR
         if: ${{ steps.guard.outputs.blocked == 'true' }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
             const body = [

--- a/.github/workflows/guard-dev-prs-to-main.yml
+++ b/.github/workflows/guard-dev-prs-to-main.yml
@@ -1,0 +1,89 @@
+name: Guard Dev PRs To Main
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - ready_for_review
+
+jobs:
+  enforce-dev-pr-path:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Detect blocked PR path
+        id: guard
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$BASE_REF" == "main" && "$HEAD_REF" == dev/* ]]; then
+            echo "blocked=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "blocked=false" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on blocked PR
+        if: ${{ steps.guard.outputs.blocked == 'true' }}
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const body = [
+              "<!-- itx-dev-pr-to-main-guard -->",
+              "Can't merge this PR into `main` from this branch.",
+              "This pull request cannot be merged into main. It must merge into preview before main. Change the base branch to preview."
+            ].join("\n\n");
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((comment) =>
+              comment.user?.type === "Bot" &&
+              comment.body?.includes("<!-- itx-dev-pr-to-main-guard -->")
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body,
+            });
+
+      - name: Fail blocked PR
+        if: ${{ steps.guard.outputs.blocked == 'true' }}
+        run: |
+          echo "Pull requests from dev/* must target preview before main."
+          exit 1
+
+      - name: Allow valid PR path
+        if: ${{ steps.guard.outputs.blocked != 'true' }}
+        run: echo "Pull request path is allowed."


### PR DESCRIPTION
Adds a GitHub Actions guard that blocks pull requests from dev/* branches directly into main.

This change introduces a new workflow, [guard-dev-prs-to-main.yml], which runs on PRs targeting main. If the PR head branch matches dev/*, the workflow posts a clear guidance comment telling the author to retarget the PR to preview, then fails the check so the PR cannot be merged. The comment is deduplicated by marker so repeated workflow runs update the same bot comment instead of adding noise.

This is intended to work with the new repository rulesets already applied in GitHub for main and preview, where both branches now require PRs, block direct updates, and block force pushes.