### PR TITLE
fix(db): harden advisor RLS policies per CodeRabbit round 2 (#621)

### DIFF
--- a/supabase/sql/advisor_service_role_only_policies.sql
+++ b/supabase/sql/advisor_service_role_only_policies.sql
@@ -24,6 +24,10 @@ begin
     'super_admin_email_challenges'
   ]
   loop
+    -- CodeRabbit: enforce RLS in the same migration so the deny policies
+    -- actually protect the table regardless of external state.
+    execute format('alter table public.%I enable row level security', t);
+    execute format('alter table public.%I force row level security', t);
     execute format('drop policy if exists %I on public.%I', t || '_service_role_only', t);
     execute format(
       'create policy %I on public.%I as restrictive for all to authenticated, anon using (false) with check (false)',

--- a/supabase/sql/z_rls_initplan_optimization.sql
+++ b/supabase/sql/z_rls_initplan_optimization.sql
@@ -18,28 +18,23 @@
 -- ============================ gear ============================
 drop policy if exists gear_read_tenant on public.gear;
 create policy gear_read_tenant on public.gear for select to public
-  using (tenant_id = (select profiles.tenant_id from profiles where profiles.id = (select auth.uid())));
+  using (tenant_id = (select current_tenant_id()));
 
 drop policy if exists gear_admin_delete on public.gear;
 create policy gear_admin_delete on public.gear for delete to public
-  using (exists (select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'tenant_admin' and profiles.tenant_id = gear.tenant_id));
+  using ((select current_user_role()) = 'tenant_admin' and gear.tenant_id = (select current_tenant_id()));
 
 drop policy if exists gear_admin_insert on public.gear;
 create policy gear_admin_insert on public.gear for insert to public
-  with check (exists (select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'tenant_admin' and profiles.tenant_id = gear.tenant_id));
+  with check ((select current_user_role()) = 'tenant_admin' and gear.tenant_id = (select current_tenant_id()));
 
 drop policy if exists gear_admin_update on public.gear;
 create policy gear_admin_update on public.gear for update to public
-  using (exists (select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'tenant_admin' and profiles.tenant_id = gear.tenant_id));
+  using ((select current_user_role()) = 'tenant_admin' and gear.tenant_id = (select current_tenant_id()));
 
 drop policy if exists gear_tenant_user_update on public.gear;
 create policy gear_tenant_user_update on public.gear for update to public
-  using (exists (select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.tenant_id = gear.tenant_id
-      and profiles.role = any (array['tenant_user','tenant_admin'])));
+  using ((select current_user_role()) = any (array['tenant_user','tenant_admin']) and gear.tenant_id = (select current_tenant_id()));
 
 -- "student checkout gear" (with space) is an exact duplicate of
 -- student_checkout_gear; drop the legacy spaced name, keep the canonical one.
@@ -59,38 +54,32 @@ create policy student_gear_update on public.gear for update to public
 -- ============================ students ============================
 drop policy if exists students_read_tenant on public.students;
 create policy students_read_tenant on public.students for select to public
-  using (tenant_id = (select profiles.tenant_id from profiles where profiles.id = (select auth.uid())));
+  using (tenant_id = (select current_tenant_id()));
 
 drop policy if exists students_admin_delete on public.students;
 create policy students_admin_delete on public.students for delete to public
-  using (exists (select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'tenant_admin' and profiles.tenant_id = students.tenant_id));
+  using ((select current_user_role()) = 'tenant_admin' and students.tenant_id = (select current_tenant_id()));
 
 drop policy if exists students_admin_insert on public.students;
 create policy students_admin_insert on public.students for insert to public
-  with check (exists (select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'tenant_admin' and profiles.tenant_id = students.tenant_id));
+  with check ((select current_user_role()) = 'tenant_admin' and students.tenant_id = (select current_tenant_id()));
 
 drop policy if exists students_admin_update on public.students;
 create policy students_admin_update on public.students for update to public
-  using (exists (select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'tenant_admin' and profiles.tenant_id = students.tenant_id));
+  using ((select current_user_role()) = 'tenant_admin' and students.tenant_id = (select current_tenant_id()));
 
 -- ============================ gear_logs ============================
 drop policy if exists gear_logs_read_tenant on public.gear_logs;
 create policy gear_logs_read_tenant on public.gear_logs for select to public
-  using (tenant_id = (select profiles.tenant_id from profiles where profiles.id = (select auth.uid())));
+  using (tenant_id = (select current_tenant_id()));
 
 drop policy if exists gear_logs_insert on public.gear_logs;
 create policy gear_logs_insert on public.gear_logs for insert to public
-  with check (exists (select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.tenant_id = gear_logs.tenant_id));
+  with check ((select current_user_role()) is not null and gear_logs.tenant_id = (select current_tenant_id()));
 
 drop policy if exists gear_logs_insert_tenant_user on public.gear_logs;
 create policy gear_logs_insert_tenant_user on public.gear_logs for insert to public
-  with check (exists (select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.tenant_id = gear_logs.tenant_id
-      and profiles.role = any (array['tenant_user','tenant_admin'])));
+  with check ((select current_user_role()) = any (array['tenant_user','tenant_admin']) and gear_logs.tenant_id = (select current_tenant_id()));
 
 -- ============================ profiles ============================
 drop policy if exists profiles_read_own on public.profiles;
@@ -99,7 +88,7 @@ create policy profiles_read_own on public.profiles for select to public
 
 drop policy if exists profiles_super_admin_read_all on public.profiles;
 create policy profiles_super_admin_read_all on public.profiles for select to public
-  using ((select auth.role()) = 'super_admin');
+  using ((select current_user_role()) = 'super_admin' and (select has_recent_privileged_step_up('super_admin')));
 
 drop policy if exists self_select_profile on public.profiles;
 create policy self_select_profile on public.profiles for select to authenticated
@@ -107,19 +96,16 @@ create policy self_select_profile on public.profiles for select to authenticated
 
 -- ============================ admin_audit_logs ============================
 drop policy if exists admin_audit_logs_read on public.admin_audit_logs;
-create policy admin_audit_logs_read on public.admin_audit_logs for select to public
-  using (exists (select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'tenant_admin' and profiles.tenant_id = admin_audit_logs.tenant_id));
+create policy admin_audit_logs_read on public.admin_audit_logs for select to authenticated
+  using ((select current_user_role()) = 'tenant_admin' and tenant_id = (select current_tenant_id()));
 
 drop policy if exists admin_audit_logs_read_super_admin on public.admin_audit_logs;
-create policy admin_audit_logs_read_super_admin on public.admin_audit_logs for select to public
-  using (exists (select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'super_admin'));
+-- CodeRabbit: dropped — super_admin_all_admin_audit_logs already grants super_admin
+-- SELECT *with* step-up; this permissive no-step-up policy was a bypass.
 
 drop policy if exists admin_audit_logs_insert on public.admin_audit_logs;
-create policy admin_audit_logs_insert on public.admin_audit_logs for insert to public
-  with check (exists (select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'tenant_admin' and profiles.tenant_id = admin_audit_logs.tenant_id));
+-- CodeRabbit: dropped — tenant_admin_insert_admin_audit_logs covers tenant_admin
+-- INSERT *with* step-up + actor_id check; this permissive policy bypassed it.
 
 drop policy if exists super_admin_all_admin_audit_logs on public.admin_audit_logs;
 create policy super_admin_all_admin_audit_logs on public.admin_audit_logs for all to authenticated
@@ -145,33 +131,33 @@ create policy super_admin_all_runtime_config on public.app_runtime_config for al
 -- async_jobs
 drop policy if exists super_admin_select_async_jobs on public.async_jobs;
 create policy super_admin_select_async_jobs on public.async_jobs for select to authenticated
-  using (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.role = 'super_admin')
+  using (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.is_active = true and p.role = 'super_admin')
     and (select has_recent_privileged_step_up('super_admin')));
 
 -- client_error_reports
 drop policy if exists super_admin_select_client_error_reports on public.client_error_reports;
 create policy super_admin_select_client_error_reports on public.client_error_reports for select to authenticated
-  using (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.role = 'super_admin')
+  using (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.is_active = true and p.role = 'super_admin')
     and (select has_recent_privileged_step_up('super_admin')));
 
 -- customer_status_logs
 drop policy if exists super_admin_select_customer_status_logs on public.customer_status_logs;
 create policy super_admin_select_customer_status_logs on public.customer_status_logs for select to authenticated
-  using (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.role = 'super_admin')
+  using (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.is_active = true and p.role = 'super_admin')
     and (select has_recent_privileged_step_up('super_admin')));
 
 -- district_support_requests
 drop policy if exists district_admin_insert_own_support_requests on public.district_support_requests;
 create policy district_admin_insert_own_support_requests on public.district_support_requests for insert to authenticated
   with check (
-    exists (select 1 from profiles p where p.id = (select auth.uid()) and p.role = 'district_admin' and p.district_id = district_support_requests.district_id)
-    or (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.role = 'super_admin') and (select has_recent_privileged_step_up('super_admin'))));
+    exists (select 1 from profiles p where p.id = (select auth.uid()) and p.is_active = true and p.role = 'district_admin' and p.district_id = district_support_requests.district_id)
+    or (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.is_active = true and p.role = 'super_admin') and (select has_recent_privileged_step_up('super_admin'))));
 
 drop policy if exists district_admin_select_own_support_requests on public.district_support_requests;
 create policy district_admin_select_own_support_requests on public.district_support_requests for select to authenticated
   using (
-    (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.role = 'district_admin' and p.district_id = district_support_requests.district_id) and (select has_recent_privileged_step_up('district_admin')))
-    or (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.role = 'super_admin') and (select has_recent_privileged_step_up('super_admin'))));
+    (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.is_active = true and p.role = 'district_admin' and p.district_id = district_support_requests.district_id) and (select has_recent_privileged_step_up('district_admin')))
+    or (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.is_active = true and p.role = 'super_admin') and (select has_recent_privileged_step_up('super_admin'))));
 
 -- districts
 drop policy if exists super_admin_all_districts on public.districts;
@@ -196,27 +182,27 @@ create policy tenant_select_gear_status_history on public.gear_status_history fo
 -- rate_limits
 drop policy if exists rate_limits_access on public.rate_limits;
 create policy rate_limits_access on public.rate_limits for all to public
-  using (exists (select 1 from profiles where profiles.id = (select auth.uid()) and profiles.tenant_id = rate_limits.tenant_id
+  using (exists (select 1 from profiles where profiles.id = (select auth.uid()) and profiles.is_active = true and profiles.tenant_id = rate_limits.tenant_id
     and (rate_limits.actor_id = (select auth.uid()) or rate_limits.actor_id = rate_limits.tenant_id)))
-  with check (exists (select 1 from profiles where profiles.id = (select auth.uid()) and profiles.tenant_id = rate_limits.tenant_id
+  with check (exists (select 1 from profiles where profiles.id = (select auth.uid()) and profiles.is_active = true and profiles.tenant_id = rate_limits.tenant_id
     and (rate_limits.actor_id = (select auth.uid()) or rate_limits.actor_id = rate_limits.tenant_id)));
 
 -- sales_leads
 drop policy if exists super_admin_select_sales_leads on public.sales_leads;
 create policy super_admin_select_sales_leads on public.sales_leads for select to authenticated
-  using (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.role = 'super_admin')
+  using (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.is_active = true and p.role = 'super_admin')
     and (select has_recent_privileged_step_up('super_admin')));
 
 -- subprocessor_changes
 drop policy if exists super_admin_select_subprocessor_changes on public.subprocessor_changes;
 create policy super_admin_select_subprocessor_changes on public.subprocessor_changes for select to authenticated
-  using (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.role = 'super_admin')
+  using (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.is_active = true and p.role = 'super_admin')
     and (select has_recent_privileged_step_up('super_admin')));
 
 -- super_admin_audit_logs
 drop policy if exists super_admin_insert_super_admin_audit_logs on public.super_admin_audit_logs;
 create policy super_admin_insert_super_admin_audit_logs on public.super_admin_audit_logs for insert to authenticated
-  with check (actor_id = (select auth.uid()) and exists (select 1 from profiles p where p.id = (select auth.uid()) and p.role = 'super_admin')
+  with check (actor_id = (select auth.uid()) and exists (select 1 from profiles p where p.id = (select auth.uid()) and p.is_active = true and p.role = 'super_admin')
     and (select has_recent_privileged_step_up('super_admin')));
 
 drop policy if exists super_admin_insert_super_audit_logs on public.super_admin_audit_logs;
@@ -225,7 +211,7 @@ create policy super_admin_insert_super_audit_logs on public.super_admin_audit_lo
 
 drop policy if exists super_admin_select_super_admin_audit_logs on public.super_admin_audit_logs;
 create policy super_admin_select_super_admin_audit_logs on public.super_admin_audit_logs for select to authenticated
-  using (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.role = 'super_admin')
+  using (exists (select 1 from profiles p where p.id = (select auth.uid()) and p.is_active = true and p.role = 'super_admin')
     and (select has_recent_privileged_step_up('super_admin')));
 
 drop policy if exists super_admin_select_super_audit_logs on public.super_admin_audit_logs;
@@ -235,7 +221,7 @@ create policy super_admin_select_super_audit_logs on public.super_admin_audit_lo
 -- super_admin_sessions
 drop policy if exists super_admin_sessions_select_own on public.super_admin_sessions;
 create policy super_admin_sessions_select_own on public.super_admin_sessions for select to authenticated
-  using ((select auth.uid()) = profile_id and exists (select 1 from profiles p where p.id = (select auth.uid()) and p.role = 'super_admin')
+  using ((select auth.uid()) = profile_id and exists (select 1 from profiles p where p.id = (select auth.uid()) and p.is_active = true and p.role = 'super_admin')
     and (select has_recent_privileged_step_up('super_admin')));
 
 -- super_alert_rules
@@ -284,7 +270,7 @@ create policy super_admin_update_support_requests on public.support_requests for
 drop policy if exists tenant_admin_sessions_select_own on public.tenant_admin_sessions;
 create policy tenant_admin_sessions_select_own on public.tenant_admin_sessions for select to authenticated
   using ((select auth.uid()) = profile_id and tenant_id = (select current_tenant_id())
-    and exists (select 1 from profiles p where p.id = (select auth.uid()) and p.role = 'tenant_admin' and p.is_active = true));
+    and exists (select 1 from profiles p where p.id = (select auth.uid()) and p.is_active = true and p.role = 'tenant_admin' and p.is_active = true));
 
 -- tenant_policies
 drop policy if exists super_admin_all_tenant_policies on public.tenant_policies;
@@ -322,5 +308,5 @@ create policy tenant_self_select_tenants on public.tenants for select to authent
   using ((select current_user_role()) = any (array['tenant_user','tenant_admin']) and id = (select current_tenant_id()));
 
 drop policy if exists tenants_super_admin_read on public.tenants;
-create policy tenants_super_admin_read on public.tenants for select to authenticated
-  using (exists (select 1 from profiles where profiles.id = (select auth.uid()) and profiles.role = 'super_admin'));
+-- CodeRabbit: dropped — super_admin_all_tenants grants super_admin SELECT *with*
+-- step-up; this no-step-up policy was a bypass.


### PR DESCRIPTION
Second round of CodeRabbit fixes on #621.

- **service_role deny policies** — `enable`/`force row level security` in the same loop so the deny invariant holds regardless of external state.
- **z_rls** — raw `profiles.role` subqueries → `current_user_role()`/`current_tenant_id()` (enforces `is_active` + app role; `auth.role()` was the Postgres role claim, not the app role).
- **profiles_super_admin_read_all** — `current_user_role()='super_admin'` + step-up.
- **Dropped no-step-up bypass policies** that OR'd ahead of stricter step-up ones: `admin_audit_logs_read_super_admin`, `admin_audit_logs_insert`, `tenants_super_admin_read`.
- `is_active` guard added to remaining membership checks (rate_limits, gear_logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)