### PR TITLE
fix(actions): disable persisted checkout credentials in workflows

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,6 +59,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4

--- a/.github/workflows/deploy-cloudflare-worker.yml
+++ b/.github/workflows/deploy-cloudflare-worker.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/deploy-supabase-functions.yml
+++ b/.github/workflows/deploy-supabase-functions.yml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/manage-kill-switch.yml
+++ b/.github/workflows/manage-kill-switch.yml
@@ -56,6 +56,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/synthetic-journeys.yml
+++ b/.github/workflows/synthetic-journeys.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Run production synthetic smoke checks
         run: bash ./scripts/synthetic-smoke.sh

--- a/.github/workflows/vercel-analytics-report.yml
+++ b/.github/workflows/vercel-analytics-report.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Summary
This PR fixes the Aikido SAST finding about `actions/checkout` persisting `GITHUB_TOKEN` into local git config during workflow runs.

It adds `persist-credentials: false` to the checkout step in the affected workflows so later steps and third-party actions cannot read the default checkout token from git config unless a workflow explicitly opts into that behavior.

## Changes
- Updated checkout steps in:
  - `ci-core.yml`
  - `codeql.yml`
  - `deploy-cloudflare-worker.yml`
  - `deploy-supabase-functions.yml`
  - `e2e.yml`
  - `manage-kill-switch.yml`
  - `security-audit.yml`
  - `synthetic-journeys.yml`
  - `vercel-analytics-report.yml`

## Validation
- Confirmed none of the updated workflows perform authenticated `git push`, so disabling persisted checkout credentials is safe.
- Parsed all updated workflow YAML files successfully.
- Ran local workflow-equivalent checks:
  - `npm run build`
  - `npm run perf:budget`
  - `npm run perf:images`
  - `npm run perf:report`
  - `npm run security:gate`
  - `npm run security:sbom`
  - `npm run test:e2e` (`31 passed`)
  - `bash ./scripts/synthetic-smoke.sh`