### PR TITLE
Integrate ItemTraxx code with devops automation hub workflows

### DIFF
--- a/.github/workflows/ci-triage.yml
+++ b/.github/workflows/ci-triage.yml
@@ -26,29 +26,14 @@ jobs:
       actions: read
       contents: read
     steps:
-      - name: Check hub token
-        id: hub
-        env:
-          DEVOPS_HUB_TOKEN: ${{ secrets.DEVOPS_HUB_TOKEN }}
-        run: |
-          if [ -n "$DEVOPS_HUB_TOKEN" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "DEVOPS_HUB_TOKEN is not configured; skipping hub CI triage."
-          fi
-
       - name: Checkout devops hub
-        if: ${{ steps.hub.outputs.available == 'true' }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ItemTraxxCo/devops
-          token: ${{ secrets.DEVOPS_HUB_TOKEN }}
           path: devops-hub
           persist-credentials: false
 
       - name: Run CI triage
-        if: ${{ steps.hub.outputs.available == 'true' }}
         uses: ./devops-hub/actions/ci-triage
         with:
           run_id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/ci-triage.yml
+++ b/.github/workflows/ci-triage.yml
@@ -28,5 +28,5 @@ jobs:
       run_id: ${{ format('{0}', github.event.workflow_run.id) }}
       workflow_name: ${{ github.event.workflow_run.name }}
     secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      AI_API_KEY: ${{ secrets.AI_API_KEY }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci-triage.yml
+++ b/.github/workflows/ci-triage.yml
@@ -1,0 +1,32 @@
+name: CI Triage
+
+permissions: {}
+
+on:
+  workflow_run:
+    workflows:
+      - CI Core
+      - E2E Tests
+      - Security Audit
+      - CodeQL
+      - Deploy Supabase Functions
+      - Deploy Cloudflare Worker
+      - Deployment Health
+      - Synthetic Journeys
+      - Synthetic Probes (Hub)
+    types:
+      - completed
+
+jobs:
+  triage:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    uses: ItemTraxxCo/devops/.github/workflows/reusable-ci-triage.yml@main
+    permissions:
+      actions: read
+      contents: read
+    with:
+      run_id: ${{ github.event.workflow_run.id }}
+      workflow_name: ${{ github.event.workflow_run.name }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci-triage.yml
+++ b/.github/workflows/ci-triage.yml
@@ -25,7 +25,7 @@ jobs:
       actions: read
       contents: read
     with:
-      run_id: ${{ github.event.workflow_run.id }}
+      run_id: ${{ format('{0}', github.event.workflow_run.id) }}
       workflow_name: ${{ github.event.workflow_run.name }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/ci-triage.yml
+++ b/.github/workflows/ci-triage.yml
@@ -20,13 +20,39 @@ on:
 jobs:
   triage:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    uses: ItemTraxxCo/devops/.github/workflows/reusable-ci-triage.yml@main
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
-    with:
-      run_id: ${{ format('{0}', github.event.workflow_run.id) }}
-      workflow_name: ${{ github.event.workflow_run.name }}
-    secrets:
-      AI_API_KEY: ${{ secrets.AI_API_KEY }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - name: Check hub token
+        id: hub
+        env:
+          DEVOPS_HUB_TOKEN: ${{ secrets.DEVOPS_HUB_TOKEN }}
+        run: |
+          if [ -n "$DEVOPS_HUB_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "DEVOPS_HUB_TOKEN is not configured; skipping hub CI triage."
+          fi
+
+      - name: Checkout devops hub
+        if: ${{ steps.hub.outputs.available == 'true' }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ItemTraxxCo/devops
+          token: ${{ secrets.DEVOPS_HUB_TOKEN }}
+          path: devops-hub
+          persist-credentials: false
+
+      - name: Run CI triage
+        if: ${{ steps.hub.outputs.available == 'true' }}
+        uses: ./devops-hub/actions/ci-triage
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          repository: ${{ github.repository }}
+          github_token: ${{ github.token }}
+          ai_api_key: ${{ secrets.AI_API_KEY }}
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dependabot-promotion.yml
+++ b/.github/workflows/dependabot-promotion.yml
@@ -2,8 +2,8 @@ name: Dependabot Promotion
 
 # Uses pull_request_target so the run has a write-capable token for
 # labeling. Safe because neither this workflow nor the hub action it runs
-# ever checks out or executes PR code — only the private devops hub repo
-# is checked out, and only Dependabot metadata is read.
+# ever checks out or executes PR code — only the public devops hub repo is
+# checked out, and only Dependabot metadata is read.
 
 permissions: {}
 
@@ -24,29 +24,14 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - name: Check hub token
-        id: hub
-        env:
-          DEVOPS_HUB_TOKEN: ${{ secrets.DEVOPS_HUB_TOKEN }}
-        run: |
-          if [ -n "$DEVOPS_HUB_TOKEN" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "DEVOPS_HUB_TOKEN is not configured (needs to exist as a Dependabot secret too); skipping promotion."
-          fi
-
       - name: Checkout devops hub
-        if: ${{ steps.hub.outputs.available == 'true' }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ItemTraxxCo/devops
-          token: ${{ secrets.DEVOPS_HUB_TOKEN }}
           path: devops-hub
           persist-credentials: false
 
       - name: Run dependency promotion
-        if: ${{ steps.hub.outputs.available == 'true' }}
         uses: ./devops-hub/actions/dependabot-promotion
         with:
           pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/dependabot-promotion.yml
+++ b/.github/workflows/dependabot-promotion.yml
@@ -1,9 +1,9 @@
 name: Dependabot Promotion
 
-# Uses pull_request_target so the run has normal Actions secrets and a
-# write-capable token for labeling. Safe because neither this workflow nor
-# the hub workflow it calls ever checks out or executes PR code — only
-# Dependabot metadata is read.
+# Uses pull_request_target so the run has a write-capable token for
+# labeling. Safe because neither this workflow nor the hub action it runs
+# ever checks out or executes PR code — only the private devops hub repo
+# is checked out, and only Dependabot metadata is read.
 
 permissions: {}
 
@@ -17,11 +17,39 @@ on:
 jobs:
   promote:
     if: ${{ github.actor == 'dependabot[bot]' }}
-    uses: ItemTraxxCo/devops/.github/workflows/reusable-dependency-promotion.yml@main
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: write
       issues: write
-    with:
-      pr_number: ${{ format('{0}', github.event.pull_request.number) }}
-      enable_automerge: false
+    steps:
+      - name: Check hub token
+        id: hub
+        env:
+          DEVOPS_HUB_TOKEN: ${{ secrets.DEVOPS_HUB_TOKEN }}
+        run: |
+          if [ -n "$DEVOPS_HUB_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "DEVOPS_HUB_TOKEN is not configured (needs to exist as a Dependabot secret too); skipping promotion."
+          fi
+
+      - name: Checkout devops hub
+        if: ${{ steps.hub.outputs.available == 'true' }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ItemTraxxCo/devops
+          token: ${{ secrets.DEVOPS_HUB_TOKEN }}
+          path: devops-hub
+          persist-credentials: false
+
+      - name: Run dependency promotion
+        if: ${{ steps.hub.outputs.available == 'true' }}
+        uses: ./devops-hub/actions/dependabot-promotion
+        with:
+          pr_number: ${{ github.event.pull_request.number }}
+          repository: ${{ github.repository }}
+          github_token: ${{ github.token }}
+          enable_automerge: "false"

--- a/.github/workflows/dependabot-promotion.yml
+++ b/.github/workflows/dependabot-promotion.yml
@@ -23,5 +23,5 @@ jobs:
       pull-requests: write
       issues: write
     with:
-      pr_number: ${{ github.event.pull_request.number }}
+      pr_number: ${{ format('{0}', github.event.pull_request.number) }}
       enable_automerge: false

--- a/.github/workflows/dependabot-promotion.yml
+++ b/.github/workflows/dependabot-promotion.yml
@@ -1,0 +1,27 @@
+name: Dependabot Promotion
+
+# Uses pull_request_target so the run has normal Actions secrets and a
+# write-capable token for labeling. Safe because neither this workflow nor
+# the hub workflow it calls ever checks out or executes PR code — only
+# Dependabot metadata is read.
+
+permissions: {}
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  promote:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    uses: ItemTraxxCo/devops/.github/workflows/reusable-dependency-promotion.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      enable_automerge: false

--- a/.github/workflows/deploy-evidence.yml
+++ b/.github/workflows/deploy-evidence.yml
@@ -18,7 +18,7 @@ jobs:
       actions: read
       contents: read
     with:
-      run_id: ${{ github.event.workflow_run.id }}
+      run_id: ${{ format('{0}', github.event.workflow_run.id) }}
       sha: ${{ github.event.workflow_run.head_sha }}
       workflow_name: ${{ github.event.workflow_run.name }}
       surfaces: ${{ github.event.workflow_run.name == 'Deploy Supabase Functions' && 'supabase-functions' || 'cloudflare-worker' }}

--- a/.github/workflows/deploy-evidence.yml
+++ b/.github/workflows/deploy-evidence.yml
@@ -23,4 +23,4 @@ jobs:
       workflow_name: ${{ github.event.workflow_run.name }}
       surfaces: ${{ github.event.workflow_run.name == 'Deploy Supabase Functions' && 'supabase-functions' || 'cloudflare-worker' }}
     secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      AI_API_KEY: ${{ secrets.AI_API_KEY }}

--- a/.github/workflows/deploy-evidence.yml
+++ b/.github/workflows/deploy-evidence.yml
@@ -13,14 +13,41 @@ on:
 jobs:
   evidence:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    uses: ItemTraxxCo/devops/.github/workflows/reusable-deploy-evidence.yml@main
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
-    with:
-      run_id: ${{ format('{0}', github.event.workflow_run.id) }}
-      sha: ${{ github.event.workflow_run.head_sha }}
-      workflow_name: ${{ github.event.workflow_run.name }}
-      surfaces: ${{ github.event.workflow_run.name == 'Deploy Supabase Functions' && 'supabase-functions' || 'cloudflare-worker' }}
-    secrets:
-      AI_API_KEY: ${{ secrets.AI_API_KEY }}
+    steps:
+      - name: Check hub token
+        id: hub
+        env:
+          DEVOPS_HUB_TOKEN: ${{ secrets.DEVOPS_HUB_TOKEN }}
+        run: |
+          if [ -n "$DEVOPS_HUB_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "DEVOPS_HUB_TOKEN is not configured; skipping deploy evidence."
+          fi
+
+      - name: Checkout devops hub
+        if: ${{ steps.hub.outputs.available == 'true' }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ItemTraxxCo/devops
+          token: ${{ secrets.DEVOPS_HUB_TOKEN }}
+          path: devops-hub
+          persist-credentials: false
+
+      - name: Build deploy evidence bundle
+        if: ${{ steps.hub.outputs.available == 'true' }}
+        uses: ./devops-hub/actions/collect-deploy-evidence
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          repository: ${{ github.repository }}
+          sha: ${{ github.event.workflow_run.head_sha }}
+          github_token: ${{ github.token }}
+          workflow_name: ${{ github.event.workflow_run.name }}
+          surfaces: ${{ github.event.workflow_run.name == 'Deploy Supabase Functions' && 'supabase-functions' || 'cloudflare-worker' }}
+          ai_api_key: ${{ secrets.AI_API_KEY }}

--- a/.github/workflows/deploy-evidence.yml
+++ b/.github/workflows/deploy-evidence.yml
@@ -1,0 +1,26 @@
+name: Deploy Evidence
+
+permissions: {}
+
+on:
+  workflow_run:
+    workflows:
+      - Deploy Supabase Functions
+      - Deploy Cloudflare Worker
+    types:
+      - completed
+
+jobs:
+  evidence:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: ItemTraxxCo/devops/.github/workflows/reusable-deploy-evidence.yml@main
+    permissions:
+      actions: read
+      contents: read
+    with:
+      run_id: ${{ github.event.workflow_run.id }}
+      sha: ${{ github.event.workflow_run.head_sha }}
+      workflow_name: ${{ github.event.workflow_run.name }}
+      surfaces: ${{ github.event.workflow_run.name == 'Deploy Supabase Functions' && 'supabase-functions' || 'cloudflare-worker' }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/deploy-evidence.yml
+++ b/.github/workflows/deploy-evidence.yml
@@ -19,29 +19,14 @@ jobs:
       actions: read
       contents: read
     steps:
-      - name: Check hub token
-        id: hub
-        env:
-          DEVOPS_HUB_TOKEN: ${{ secrets.DEVOPS_HUB_TOKEN }}
-        run: |
-          if [ -n "$DEVOPS_HUB_TOKEN" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "DEVOPS_HUB_TOKEN is not configured; skipping deploy evidence."
-          fi
-
       - name: Checkout devops hub
-        if: ${{ steps.hub.outputs.available == 'true' }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ItemTraxxCo/devops
-          token: ${{ secrets.DEVOPS_HUB_TOKEN }}
           path: devops-hub
           persist-credentials: false
 
       - name: Build deploy evidence bundle
-        if: ${{ steps.hub.outputs.available == 'true' }}
         uses: ./devops-hub/actions/collect-deploy-evidence
         with:
           run_id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/pr-risk-review.yml
+++ b/.github/workflows/pr-risk-review.yml
@@ -21,4 +21,4 @@ jobs:
     with:
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
     secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      AI_API_KEY: ${{ secrets.AI_API_KEY }}

--- a/.github/workflows/pr-risk-review.yml
+++ b/.github/workflows/pr-risk-review.yml
@@ -19,6 +19,6 @@ jobs:
       pull-requests: write
       issues: write
     with:
-      pr_number: ${{ github.event.pull_request.number }}
+      pr_number: ${{ format('{0}', github.event.pull_request.number) }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/pr-risk-review.yml
+++ b/.github/workflows/pr-risk-review.yml
@@ -13,12 +13,39 @@ on:
 jobs:
   risk-review:
     if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' }}
-    uses: ItemTraxxCo/devops/.github/workflows/reusable-pr-risk-review.yml@main
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
       issues: write
-    with:
-      pr_number: ${{ format('{0}', github.event.pull_request.number) }}
-    secrets:
-      AI_API_KEY: ${{ secrets.AI_API_KEY }}
+    steps:
+      - name: Check hub token
+        id: hub
+        env:
+          DEVOPS_HUB_TOKEN: ${{ secrets.DEVOPS_HUB_TOKEN }}
+        run: |
+          if [ -n "$DEVOPS_HUB_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "DEVOPS_HUB_TOKEN is not configured; skipping PR risk review."
+          fi
+
+      - name: Checkout devops hub
+        if: ${{ steps.hub.outputs.available == 'true' }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ItemTraxxCo/devops
+          token: ${{ secrets.DEVOPS_HUB_TOKEN }}
+          path: devops-hub
+          persist-credentials: false
+
+      - name: Run PR risk review
+        if: ${{ steps.hub.outputs.available == 'true' }}
+        uses: ./devops-hub/actions/pr-risk-review
+        with:
+          pr_number: ${{ github.event.pull_request.number }}
+          repository: ${{ github.repository }}
+          github_token: ${{ github.token }}
+          ai_api_key: ${{ secrets.AI_API_KEY }}

--- a/.github/workflows/pr-risk-review.yml
+++ b/.github/workflows/pr-risk-review.yml
@@ -1,0 +1,24 @@
+name: PR Risk Review
+
+permissions: {}
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  risk-review:
+    if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' }}
+    uses: ItemTraxxCo/devops/.github/workflows/reusable-pr-risk-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/pr-risk-review.yml
+++ b/.github/workflows/pr-risk-review.yml
@@ -20,29 +20,14 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - name: Check hub token
-        id: hub
-        env:
-          DEVOPS_HUB_TOKEN: ${{ secrets.DEVOPS_HUB_TOKEN }}
-        run: |
-          if [ -n "$DEVOPS_HUB_TOKEN" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "DEVOPS_HUB_TOKEN is not configured; skipping PR risk review."
-          fi
-
       - name: Checkout devops hub
-        if: ${{ steps.hub.outputs.available == 'true' }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ItemTraxxCo/devops
-          token: ${{ secrets.DEVOPS_HUB_TOKEN }}
           path: devops-hub
           persist-credentials: false
 
       - name: Run PR risk review
-        if: ${{ steps.hub.outputs.available == 'true' }}
         uses: ./devops-hub/actions/pr-risk-review
         with:
           pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/slack-notify-failure.yml
+++ b/.github/workflows/slack-notify-failure.yml
@@ -1,5 +1,8 @@
 name: Slack Notify Failure
 
+# Thin shim: delegates to the ItemTraxxCo/devops automation hub.
+# Interface is unchanged for all in-repo callers.
+
 permissions: {}
 
 on:
@@ -29,82 +32,15 @@ on:
         required: false
 
 jobs:
-  notify:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send Slack failure notification
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          WORKFLOW_NAME: ${{ inputs.workflow_name }}
-          JOB_NAME: ${{ inputs.job_name }}
-          RUN_URL: ${{ inputs.run_url }}
-          REF_NAME: ${{ inputs.ref_name }}
-          SHA: ${{ inputs.sha }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          SHORT_SHA="$(printf '%s' "$SHA" | cut -c1-7)"
-          PAYLOAD="$(cat <<EOF
-          {
-            "text": "GitHub Actions failure",
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": ":x: GitHub Actions failure"
-                }
-              },
-              {
-                "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Workflow:*\n$WORKFLOW_NAME"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Job:*\n$JOB_NAME"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Branch:*\n$REF_NAME"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Commit:*\n$SHORT_SHA"
-                  }
-                ]
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "*Repository:* $REPOSITORY\n*Run:* <$RUN_URL|Open failing run>"
-                }
-              }
-            ]
-          }
-          EOF
-          )"
-          curl -fsSL -X POST "$SLACK_WEBHOOK_URL" \
-            -H "Content-Type: application/json" \
-            --data "$PAYLOAD"
-
-  incidentio-notify-failure:
-    needs:
-      - notify
-    if: ${{ always() && (needs.notify.result == 'failure' || needs.notify.result == 'cancelled') }}
-    uses: ./.github/workflows/incidentio-workflow-alert.yml
+  hub:
+    uses: ItemTraxxCo/devops/.github/workflows/reusable-slack-notify-failure.yml@main
     with:
-      status: ${{ needs.notify.result }}
-      severity: high
-      workflow_name: Slack Notify Failure
-      job_name: notify
+      workflow_name: ${{ inputs.workflow_name }}
+      job_name: ${{ inputs.job_name }}
       run_url: ${{ inputs.run_url }}
-      repository: ${{ github.repository }}
-      branch: ${{ inputs.ref_name }}
+      ref_name: ${{ inputs.ref_name }}
       sha: ${{ inputs.sha }}
-      environment: production
     secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       INCIDENT_IO_WEBHOOK_URL: ${{ secrets.INCIDENT_IO_WEBHOOK_URL }}
       INCIDENT_IO_WEBHOOK_TOKEN: ${{ secrets.INCIDENT_IO_WEBHOOK_TOKEN }}

--- a/.github/workflows/slack-notify-failure.yml
+++ b/.github/workflows/slack-notify-failure.yml
@@ -1,8 +1,5 @@
 name: Slack Notify Failure
 
-# Thin shim: delegates to the ItemTraxxCo/devops automation hub.
-# Interface is unchanged for all in-repo callers.
-
 permissions: {}
 
 on:
@@ -32,15 +29,82 @@ on:
         required: false
 
 jobs:
-  hub:
-    uses: ItemTraxxCo/devops/.github/workflows/reusable-slack-notify-failure.yml@main
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack failure notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          WORKFLOW_NAME: ${{ inputs.workflow_name }}
+          JOB_NAME: ${{ inputs.job_name }}
+          RUN_URL: ${{ inputs.run_url }}
+          REF_NAME: ${{ inputs.ref_name }}
+          SHA: ${{ inputs.sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          SHORT_SHA="$(printf '%s' "$SHA" | cut -c1-7)"
+          PAYLOAD="$(cat <<EOF
+          {
+            "text": "GitHub Actions failure",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": ":x: GitHub Actions failure"
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Workflow:*\n$WORKFLOW_NAME"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Job:*\n$JOB_NAME"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Branch:*\n$REF_NAME"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Commit:*\n$SHORT_SHA"
+                  }
+                ]
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*Repository:* $REPOSITORY\n*Run:* <$RUN_URL|Open failing run>"
+                }
+              }
+            ]
+          }
+          EOF
+          )"
+          curl -fsSL -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            --data "$PAYLOAD"
+
+  incidentio-notify-failure:
+    needs:
+      - notify
+    if: ${{ always() && (needs.notify.result == 'failure' || needs.notify.result == 'cancelled') }}
+    uses: ./.github/workflows/incidentio-workflow-alert.yml
     with:
-      workflow_name: ${{ inputs.workflow_name }}
-      job_name: ${{ inputs.job_name }}
+      status: ${{ needs.notify.result }}
+      severity: high
+      workflow_name: Slack Notify Failure
+      job_name: notify
       run_url: ${{ inputs.run_url }}
-      ref_name: ${{ inputs.ref_name }}
+      repository: ${{ github.repository }}
+      branch: ${{ inputs.ref_name }}
       sha: ${{ inputs.sha }}
+      environment: production
     secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       INCIDENT_IO_WEBHOOK_URL: ${{ secrets.INCIDENT_IO_WEBHOOK_URL }}
       INCIDENT_IO_WEBHOOK_TOKEN: ${{ secrets.INCIDENT_IO_WEBHOOK_TOKEN }}

--- a/.github/workflows/synthetic-probes.yml
+++ b/.github/workflows/synthetic-probes.yml
@@ -9,7 +9,35 @@ on:
 
 jobs:
   probes:
-    uses: ItemTraxxCo/devops/.github/workflows/reusable-synthetic-probes.yml@main
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Check hub token
+        id: hub
+        env:
+          DEVOPS_HUB_TOKEN: ${{ secrets.DEVOPS_HUB_TOKEN }}
+        run: |
+          if [ -n "$DEVOPS_HUB_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "DEVOPS_HUB_TOKEN is not configured; skipping synthetic probes."
+          fi
+
+      - name: Checkout devops hub
+        if: ${{ steps.hub.outputs.available == 'true' }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ItemTraxxCo/devops
+          token: ${{ secrets.DEVOPS_HUB_TOKEN }}
+          path: devops-hub
+          persist-credentials: false
+
+      - name: Run synthetic probes
+        if: ${{ steps.hub.outputs.available == 'true' }}
+        uses: ./devops-hub/actions/run-probes
 
   slack-notify-failure:
     needs:

--- a/.github/workflows/synthetic-probes.yml
+++ b/.github/workflows/synthetic-probes.yml
@@ -14,29 +14,14 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Check hub token
-        id: hub
-        env:
-          DEVOPS_HUB_TOKEN: ${{ secrets.DEVOPS_HUB_TOKEN }}
-        run: |
-          if [ -n "$DEVOPS_HUB_TOKEN" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "DEVOPS_HUB_TOKEN is not configured; skipping synthetic probes."
-          fi
-
       - name: Checkout devops hub
-        if: ${{ steps.hub.outputs.available == 'true' }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ItemTraxxCo/devops
-          token: ${{ secrets.DEVOPS_HUB_TOKEN }}
           path: devops-hub
           persist-credentials: false
 
       - name: Run synthetic probes
-        if: ${{ steps.hub.outputs.available == 'true' }}
         uses: ./devops-hub/actions/run-probes
 
   slack-notify-failure:

--- a/.github/workflows/synthetic-probes.yml
+++ b/.github/workflows/synthetic-probes.yml
@@ -1,0 +1,28 @@
+name: Synthetic Probes (Hub)
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 */2 * * *"
+
+jobs:
+  probes:
+    uses: ItemTraxxCo/devops/.github/workflows/reusable-synthetic-probes.yml@main
+
+  slack-notify-failure:
+    needs:
+      - probes
+    if: ${{ always() && (needs.probes.result == 'failure' || needs.probes.result == 'cancelled') }}
+    uses: ./.github/workflows/slack-notify-failure.yml
+    with:
+      workflow_name: Synthetic Probes (Hub)
+      job_name: probes
+      run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      ref_name: ${{ github.ref_name }}
+      sha: ${{ github.sha }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      INCIDENT_IO_WEBHOOK_URL: ${{ secrets.INCIDENT_IO_WEBHOOK_URL }}
+      INCIDENT_IO_WEBHOOK_TOKEN: ${{ secrets.INCIDENT_IO_WEBHOOK_TOKEN }}


### PR DESCRIPTION
This pull request introduces several new GitHub Actions workflows to automate CI triage, PR risk review, Dependabot PR promotion, deployment evidence collection, and synthetic probe monitoring. These workflows integrate with a shared `devops-hub` repository for reusable actions, streamline automation for PRs and deployments, and enhance observability and notification for failures.

**CI and PR Automation:**

* Added `.github/workflows/ci-triage.yml` to automatically triage failed runs from key workflows (e.g., CI Core, E2E Tests, Security Audit) using a shared action, with Slack notifications for failures.
* Introduced `.github/workflows/pr-risk-review.yml` to perform automated risk reviews on new or updated pull requests (excluding Dependabot and drafts), leveraging the devops hub action and AI integration.
* Added `.github/workflows/dependabot-promotion.yml` to automatically promote Dependabot PRs by labeling and managing them using a secure workflow with write permissions.

**Deployment and Monitoring Enhancements:**

* Created `.github/workflows/deploy-evidence.yml` to collect and bundle deployment evidence after successful deploys of Supabase Functions or Cloudflare Workers, with AI integration for evidence processing.
* Added `.github/workflows/synthetic-probes.yml` to schedule and run synthetic probes every 2 hours, with automated Slack and incident notifications on failure or cancellation.