### PR TITLE
Harden devops automation workflow calls

### DIFF
--- a/.github/workflows/ci-triage.yml
+++ b/.github/workflows/ci-triage.yml
@@ -1,6 +1,8 @@
 name: CI Triage
 
-permissions: {}
+permissions:
+  actions: read
+  contents: read
 
 on:
   workflow_run:
@@ -20,10 +22,11 @@ on:
 jobs:
   triage:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    uses: ItemTraxxCo/devops/.github/workflows/reusable-ci-triage.yml@9fc8279354a5c30c2279d09bcfe452259bbc850c
+    uses: ItemTraxxCo/devops/.github/workflows/reusable-ci-triage.yml@4fd58daee1a0fccde29ffc9c896d07ea21e731ab
     with:
       run_id: ${{ format('{0}', github.event.workflow_run.id) }}
       workflow_name: ${{ github.event.workflow_run.name }}
+      hub_ref: 4fd58daee1a0fccde29ffc9c896d07ea21e731ab
     secrets:
       AI_API_KEY: ${{ secrets.AI_API_KEY }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dependabot-promotion.yml
+++ b/.github/workflows/dependabot-promotion.yml
@@ -5,7 +5,10 @@ name: Dependabot Promotion
 # ever checks out or executes PR code — only the public devops hub repo is
 # checked out, and only Dependabot metadata is read.
 
-permissions: {}
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 on:
   pull_request_target:
@@ -17,7 +20,8 @@ on:
 jobs:
   promote:
     if: ${{ github.actor == 'dependabot[bot]' }}
-    uses: ItemTraxxCo/devops/.github/workflows/reusable-dependency-promotion.yml@9fc8279354a5c30c2279d09bcfe452259bbc850c
+    uses: ItemTraxxCo/devops/.github/workflows/reusable-dependency-promotion.yml@4fd58daee1a0fccde29ffc9c896d07ea21e731ab
     with:
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
       enable_automerge: false
+      hub_ref: 4fd58daee1a0fccde29ffc9c896d07ea21e731ab

--- a/.github/workflows/deploy-evidence.yml
+++ b/.github/workflows/deploy-evidence.yml
@@ -1,6 +1,8 @@
 name: Deploy Evidence
 
-permissions: {}
+permissions:
+  actions: read
+  contents: read
 
 on:
   workflow_run:
@@ -13,11 +15,12 @@ on:
 jobs:
   evidence:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    uses: ItemTraxxCo/devops/.github/workflows/reusable-deploy-evidence.yml@9fc8279354a5c30c2279d09bcfe452259bbc850c
+    uses: ItemTraxxCo/devops/.github/workflows/reusable-deploy-evidence.yml@4fd58daee1a0fccde29ffc9c896d07ea21e731ab
     with:
       run_id: ${{ format('{0}', github.event.workflow_run.id) }}
       sha: ${{ github.event.workflow_run.head_sha }}
       workflow_name: ${{ github.event.workflow_run.name }}
       surfaces: ${{ github.event.workflow_run.name == 'Deploy Supabase Functions' && 'supabase-functions' || 'cloudflare-worker' }}
+      hub_ref: 4fd58daee1a0fccde29ffc9c896d07ea21e731ab
     secrets:
       AI_API_KEY: ${{ secrets.AI_API_KEY }}

--- a/.github/workflows/synthetic-probes.yml
+++ b/.github/workflows/synthetic-probes.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   probes:
-    uses: ItemTraxxCo/devops/.github/workflows/reusable-synthetic-probes.yml@9fc8279354a5c30c2279d09bcfe452259bbc850c
+    uses: ItemTraxxCo/devops/.github/workflows/reusable-synthetic-probes.yml@4fd58daee1a0fccde29ffc9c896d07ea21e731ab
+    with:
+      hub_ref: 4fd58daee1a0fccde29ffc9c896d07ea21e731ab
 
   slack-notify-failure:
     needs:


### PR DESCRIPTION
Fix CI Triage startup failures and harden reusable devops workflow callers by granting required permissions and passing the pinned hub ref.