### PR TITLE
Fix Aikido finding issue

### DIFF
--- a/.github/workflows/ci-triage.yml
+++ b/.github/workflows/ci-triage.yml
@@ -21,7 +21,12 @@ on:
 
 jobs:
   triage:
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'failure' &&
+        github.event.workflow_run.event != 'pull_request' &&
+        github.event.workflow_run.head_branch == github.event.repository.default_branch
+      }}
     uses: ItemTraxxCo/devops/.github/workflows/reusable-ci-triage.yml@4fd58daee1a0fccde29ffc9c896d07ea21e731ab
     with:
       run_id: ${{ format('{0}', github.event.workflow_run.id) }}

--- a/.github/workflows/deploy-evidence.yml
+++ b/.github/workflows/deploy-evidence.yml
@@ -14,7 +14,12 @@ on:
 
 jobs:
   evidence:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event != 'pull_request' &&
+        github.event.workflow_run.head_branch == github.event.repository.default_branch
+      }}
     uses: ItemTraxxCo/devops/.github/workflows/reusable-deploy-evidence.yml@4fd58daee1a0fccde29ffc9c896d07ea21e731ab
     with:
       run_id: ${{ format('{0}', github.event.workflow_run.id) }}


### PR DESCRIPTION
This pull request updates workflow conditions in two GitHub Actions workflow files to ensure that certain jobs only run for workflow runs on the default branch and not for pull requests. This helps prevent unnecessary or incorrect job executions during pull request events.

**Workflow condition improvements:**

* Updated the `triage` job in `.github/workflows/ci-triage.yml` to only run when the workflow run failed, is not triggered by a pull request, and is on the default branch.
* Updated the `evidence` job in `.github/workflows/deploy-evidence.yml` to only run when the workflow run succeeded, is not triggered by a pull request, and is on the default branch.