### PR TITLE
bugfixes and killswitch screen fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ VITE_PRIVACY_URL=
 # Local development example:
 # ITX_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:5174
 # Shared environment example:
-# ITX_ALLOWED_ORIGINS=https://itemtraxx.com,https://www.itemtraxx.com,https://status.itemtraxx.com,https://internal.itemtraxx.com,https://app.itemtraxx.com,https://itxdemo.app.itemtraxx.com,https://pentest.app.itemtraxx.com,https://pentest2.app.itemtraxx.com,https://dennis.dev.itemtraxx.com,https://leo.dev.itemtraxx.com,https://testdist.app.itemtraxx.com,https://dev.itemtraxx.com,https://preview.itemtraxx.com
+# ITX_ALLOWED_ORIGINS=https://itemtraxx.com,https://www.itemtraxx.com,https://status.itemtraxx.com,https://internal.itemtraxx.com,https://app.itemtraxx.com,https://itxdemo.app.itemtraxx.com,https://dennis.dev.itemtraxx.com,https://leo.dev.itemtraxx.com,https://testdist.app.itemtraxx.com,https://dev.itemtraxx.com,https://preview.itemtraxx.com
 ITX_ALLOWED_ORIGINS=
 # VITE_TENANT_LOGIN_FUNCTION=tenant-login
 # VITE_LOGIN_NOTIFY_FUNCTION=login-notify

--- a/cloudflare/edge-proxy/src/constants.ts
+++ b/cloudflare/edge-proxy/src/constants.ts
@@ -33,8 +33,6 @@ export const DEFAULT_ALLOWED_ORIGINS = [
   "https://internal.itemtraxx.com",
   "https://app.itemtraxx.com",
   "https://itxdemo.app.itemtraxx.com",
-  "https://pentest.app.itemtraxx.com",
-  "https://pentest2.app.itemtraxx.com",
   "https://dennis.dev.itemtraxx.com",
   "https://leo.dev.itemtraxx.com",
   "https://testdist.app.itemtraxx.com",

--- a/cloudflare/edge-proxy/src/cors.ts
+++ b/cloudflare/edge-proxy/src/cors.ts
@@ -41,8 +41,10 @@ export const withCorsHeaders = (
   allowedOrigins: string[],
   env: Env,
 ) => {
-  const originAllowed = !origin || allowedOrigins.length === 0 ||
-    isAllowedOrigin(origin, allowedOrigins, env);
+  // Requests without an Origin header are non-browser (no CORS to enforce) and
+  // are still gated downstream by trusted-ingress HMAC / auth. A present Origin
+  // must match the allowlist exactly — an empty allowlist denies, never allows.
+  const originAllowed = !origin || isAllowedOrigin(origin, allowedOrigins, env);
   const headers = origin && originAllowed
     ? { ...BASE_CORS_HEADERS, "Access-Control-Allow-Origin": origin }
     : { ...BASE_CORS_HEADERS };

--- a/cloudflare/edge-proxy/wrangler.toml
+++ b/cloudflare/edge-proxy/wrangler.toml
@@ -6,10 +6,10 @@ preview_urls = false
 
 [vars]
 # Comma-separated origins allowed to call this proxy.
-ALLOWED_ORIGINS = "https://itemtraxx.com,https://www.itemtraxx.com,https://status.itemtraxx.com,https://internal.itemtraxx.com,https://app.itemtraxx.com,https://itxdemo.app.itemtraxx.com,https://pentest.app.itemtraxx.com,https://pentest2.app.itemtraxx.com,https://dennis.dev.itemtraxx.com,https://leo.dev.itemtraxx.com,https://testdist.app.itemtraxx.com,https://dev.itemtraxx.com,https://preview.itemtraxx.com"
+ALLOWED_ORIGINS = "https://itemtraxx.com,https://www.itemtraxx.com,https://status.itemtraxx.com,https://internal.itemtraxx.com,https://app.itemtraxx.com,https://itxdemo.app.itemtraxx.com,https://dennis.dev.itemtraxx.com,https://leo.dev.itemtraxx.com,https://testdist.app.itemtraxx.com,https://dev.itemtraxx.com,https://preview.itemtraxx.com"
 TRUST_LOCAL_ORIGINS = "false"
 # Optional hard allowlist of function names (comma-separated).
-ALLOWED_FUNCTIONS = "tenant-login,checkoutReturn,checkout-borrower-lookup,create-tenant-admin,admin-gear-mutate,admin-student-mutate,admin-ops,system-status,super-tenant-mutate,super-admin-mutate,super-dashboard,super-gear-mutate,super-student-mutate,super-logs-query,super-ops,district-dashboard,district-admin-mutate,contact-sales-submit,contact-support-submit,client-error-report,consent-record,job-worker,login-notify,super-auth-verify,district-handoff,tenant-admin-mutate,privileged-step-up"
+ALLOWED_FUNCTIONS = "tenant-login,checkoutReturn,checkout-borrower-lookup,admin-gear-mutate,admin-student-mutate,admin-ops,system-status,super-tenant-mutate,super-admin-mutate,super-dashboard,super-gear-mutate,super-student-mutate,super-logs-query,super-ops,district-dashboard,district-admin-mutate,contact-sales-submit,contact-support-submit,client-error-report,consent-record,job-worker,login-notify,super-auth-verify,district-handoff,tenant-admin-mutate,privileged-step-up"
 ITX_ITEMTRAXX_KILLSWITCH_ENABLED = "false"
 SENTRY_ENVIRONMENT = "production"
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -192,7 +192,7 @@ const isSubmitConfirmationRoute = computed(() => route.path === "/submitconfirma
 const isBannerBleedRoute = computed(() => ["/legal", "/security", "/trust", "/compliance", "/faq", "/contact", "/privacy", "/cookies", "/accessibility", "/about", "/pricing", "/forgot-password", "/contact-sales", "/request-demo", "/contact-support", "/report-security-issue", "/getting-started"].includes(route.path));
 const isDarkChromeRoute = computed(() => ["/", "/landing-new", "/pricing", "/changelog", "/itemscanner"].includes(route.path));
 const isUnavailableRoute = computed(() => route.path === "/unavailable" || route.name === "public-unavailable");
-const isKillSwitchAllowedRoute = computed(() => route.path === "/" || isUnavailableRoute.value);
+const isKillSwitchAllowedRoute = computed(() => isUnavailableRoute.value);
 const hiddenMenuRoutes = new Set(["public-home", "public-unavailable", "public-pricing", "public-about", "public-security", "public-report-security-issue", "public-changelog", "public-compliance", "public-privacy", "public-cookies", "public-contact", "public-trust", "public-faq", "public-accessibility", "public-getting-started", "public-itemscanner", "public-legal", "public-forgot-password", "public-reset-password", "public-home-new2", "public-request-demo", "public-contact-sales", "public-contact-support", "public-submit-confirmation"]);
 const showTopMenu = computed(() => !hiddenMenuRoutes.has(String(route.name)));
 const showLogoutUserAction = computed(() => auth.isAuthenticated && !Boolean(route.meta.public) && route.path !== "/login");
@@ -356,7 +356,7 @@ watch(() => routeLoading.isLoading, (loading) => {
   pageLoadingTimer = window.setTimeout(() => { showPageLoading.value = true; pageLoadingTimer = null; }, 350);
 });
 watch(() => [killSwitchEnabled.value, route.path] as const, ([enabled, path]) => {
-  if (enabled && !isLocalDevMaintenanceBypass.value && path !== "/" && path !== "/unavailable") void router.replace("/unavailable");
+  if (enabled && !isLocalDevMaintenanceBypass.value && path !== "/unavailable") void router.replace("/unavailable");
 });
 watch(() => [backendUnavailable.value, route.path] as const, ([unavailable, path]) => {
   if (unavailable && !isLocalDevMaintenanceBypass.value && path !== "/unavailable") void router.replace("/unavailable");

--- a/supabase/functions/_shared/preloginGuards_test.ts
+++ b/supabase/functions/_shared/preloginGuards_test.ts
@@ -1,8 +1,38 @@
-import { resolveClientFingerprint } from "./preloginGuards.ts";
+import {
+  enforcePreloginRateLimit,
+  resolveClientFingerprint,
+} from "./preloginGuards.ts";
 
 const assert = (condition: boolean, message: string) => {
   if (!condition) throw new Error(message);
 };
+
+Deno.test("prelogin rate limit uses the service-side RPC contract", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const client = {
+    rpc: async (name: string, args: Record<string, unknown>) => {
+      calls.push({ name, ...args });
+      return { data: [{ allowed: true, retry_after_seconds: null }], error: null };
+    },
+  };
+
+  const result = await enforcePreloginRateLimit(
+    client,
+    "ip-203-0-113-42",
+    "tenant-login",
+    5,
+    60,
+  );
+
+  assert(result.ok, "expected the allowed RPC result");
+  const observedCall = calls[0];
+  if (!observedCall) throw new Error("expected an observed RPC call");
+  assert(observedCall.name === "consume_rate_limit_prelogin", "expected the prelogin RPC");
+  assert(observedCall.p_key === "ip-203-0-113-42", "expected the client key");
+  assert(observedCall.p_scope === "tenant-login", "expected the rate-limit scope");
+  assert(observedCall.p_limit === 5, "expected the rate-limit limit");
+  assert(observedCall.p_window_seconds === 60, "expected the rate-limit window");
+});
 
 Deno.test("resolveClientFingerprint prefers trusted Cloudflare IP", () => {
   const request = new Request("https://example.com", {

--- a/supabase/sql/rate_limit_rpcs.sql
+++ b/supabase/sql/rate_limit_rpcs.sql
@@ -150,10 +150,14 @@ end;
 $$;
 
 revoke all on function public.consume_rate_limit(text, integer, integer) from public;
-revoke all on function public.consume_rate_limit_prelogin(text, text, integer, integer) from public;
+-- Prelogin throttling is only ever invoked server-side with the service role
+-- (every edge function uses the service-key adminClient). Denying anon/authenticated
+-- closes direct-to-PostgREST calls that could flood rate_limits_prelogin.
+revoke all on function public.consume_rate_limit_prelogin(text, text, integer, integer)
+  from public, anon, authenticated;
 
 grant execute on function public.consume_rate_limit(text, integer, integer)
   to authenticated, service_role;
 
 grant execute on function public.consume_rate_limit_prelogin(text, text, integer, integer)
-  to anon, authenticated, service_role;
+  to service_role;


### PR DESCRIPTION
This pull request makes several security-related updates to CORS origin allowlists, rate limit enforcement, and route handling. The changes tighten access by removing unused or sensitive origins, restricts certain privileged functions, and strengthens rate limit protections. It also refines frontend logic for maintenance mode. The most important changes are summarized below:

**CORS and Allowed Origins Updates:**
* Removed `pentest.app.itemtraxx.com` and `pentest2.app.itemtraxx.com` from the allowed origins in `.env.example`, `cloudflare/edge-proxy/wrangler.toml`, and `cloudflare/edge-proxy/src/constants.ts` to restrict access from these test environments. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL26-R26) [[2]](diffhunk://#diff-35271902889d9cb51873d1f429038399c53fb96c398a462336e3f94bfecc810eL9-R12) [[3]](diffhunk://#diff-3ee116637e2c9ee641b64bd7c752b8972b2050d69f85d411822fe66b828c7e2bL36-L37)
* Updated CORS logic in `cloudflare/edge-proxy/src/cors.ts` so that an empty allowlist now denies all origins, making the allowlist stricter and more secure.

**Backend Function and Rate Limit Security:**
* Removed `create-tenant-admin` from the `ALLOWED_FUNCTIONS` list in `cloudflare/edge-proxy/wrangler.toml`, restricting direct access to this privileged function.
* Changed database permissions in `supabase/sql/rate_limit_rpcs.sql` so that the `consume_rate_limit_prelogin` function can only be executed by the `service_role`, preventing abuse from anonymous or authenticated users.
* Added a test for `enforcePreloginRateLimit` in `supabase/functions/_shared/preloginGuards_test.ts` to verify correct use of the service-side RPC contract for prelogin rate limiting.

**Frontend Maintenance Mode Logic:**
* Updated route handling in `src/App.vue` so that the kill switch maintenance mode only allows the `/unavailable` route, tightening the bypass logic for maintenance. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L195-R195) [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L359-R359)