### PR TITLE
fix(rls): require tenant-admin step-up for gear/student writes

### DIFF
--- a/scripts/check-initial-load-budget.mjs
+++ b/scripts/check-initial-load-budget.mjs
@@ -1,12 +1,23 @@
 import { readFileSync, statSync } from "node:fs";
 import { gzipSync } from "node:zlib";
-import { resolve } from "node:path";
+import { relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 export const MAX_INITIAL_MINIFIED_BYTES = 250_000;
 export const MAX_INITIAL_GZIP_BYTES = 100_000;
 const SAFE_ASSET_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*\.js$/;
 const FORBIDDEN_INITIAL_MODULE_RE = /node_modules\/(?:jspdf|html2canvas|jsbarcode|posthog-js|@sentry|@supabase)\//;
+
+const resolveAssetPath = (assetsDir, assetName) => {
+  // Asset names come from the generated HTML, but keep the read explicitly
+  // contained in the generated assets directory for defense in depth.
+  const assetPath = resolve(assetsDir, assetName);
+  const relativePath = relative(resolve(assetsDir), assetPath);
+  if (!relativePath || relativePath.startsWith("..") || relativePath.includes("/")) {
+    throw new Error(`asset path escaped assets directory: ${assetName}`);
+  }
+  return assetPath;
+};
 
 const readAssetReferences = (html) => {
   const references = [];
@@ -48,7 +59,7 @@ export const measureInitialLoad = ({
   const moduleMap = readModuleMap(moduleMapPath);
   const totals = assets.reduce(
     (result, assetName) => {
-      const assetPath = resolve(assetsDir, assetName);
+      const assetPath = resolveAssetPath(assetsDir, assetName);
       const bytes = readFileSync(assetPath);
       result.minifiedBytes += statSync(assetPath).size;
       result.gzipBytes += gzipSync(bytes).byteLength;

--- a/scripts/check-privileged-rls-policies.mjs
+++ b/scripts/check-privileged-rls-policies.mjs
@@ -1,0 +1,123 @@
+import { readFileSync } from "node:fs";
+
+const migrationPath = new URL(
+  "../supabase/sql/z_rls_initplan_optimization.sql",
+  import.meta.url,
+);
+const migration = readFileSync(migrationPath, "utf8");
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const policyPattern = (prefix, policyName) =>
+  new RegExp(
+    `${prefix}\\s+policy\\s+${prefix === "drop" ? "(?:if\\s+exists\\s+)?" : ""}(?:"${escapeRegExp(policyName)}"|${escapeRegExp(policyName)})\\s+on\\s+public\\.`,
+    "i",
+  );
+
+const requireDroppedOnly = (policyName) => {
+  if (!policyPattern("drop", policyName).test(migration)) {
+    throw new Error(`final RLS migration does not drop legacy policy ${policyName}`);
+  }
+  if (policyPattern("create", policyName).test(migration)) {
+    throw new Error(`final RLS migration recreates unsafe policy ${policyName}`);
+  }
+};
+
+const extractParenthesizedClause = (statement, keyword) => {
+  const keywordIndex = statement.toLowerCase().indexOf(keyword);
+  const openIndex = statement.indexOf("(", keywordIndex + keyword.length);
+  if (keywordIndex === -1 || openIndex === -1) {
+    return null;
+  }
+
+  let depth = 0;
+  for (let index = openIndex; index < statement.length; index += 1) {
+    if (statement[index] === "(") {
+      depth += 1;
+    } else if (statement[index] === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return statement.slice(openIndex + 1, index);
+      }
+    }
+  }
+
+  return null;
+};
+
+const normalizeSql = (value) => value.replace(/\s+/g, " ").trim().toLowerCase();
+
+const requireStepUpPolicy = (policyName, tableName) => {
+  const statement = migration.match(
+    new RegExp(
+      `create\\s+policy\\s+(?:"${escapeRegExp(policyName)}"|${escapeRegExp(policyName)})\\s+on\\s+public\\.${escapeRegExp(tableName)}[\\s\\S]*?;`,
+      "i",
+    ),
+  )?.[0];
+
+  if (!statement) {
+    throw new Error(`final RLS migration does not create ${policyName}`);
+  }
+
+  if (!/\bfor\s+all\s+to\s+authenticated\b/i.test(statement)) {
+    throw new Error(`${policyName} must be FOR ALL TO authenticated`);
+  }
+
+  const usingClause = extractParenthesizedClause(statement, "using");
+  const withCheckClause = extractParenthesizedClause(statement, "with check");
+  if (!usingClause) {
+    throw new Error(`${policyName} is missing USING`);
+  }
+  if (!withCheckClause) {
+    throw new Error(`${policyName} is missing WITH CHECK`);
+  }
+
+  const requiredPredicates = [
+    /current_user_role\(\)\)\s*=\s*'tenant_admin'/i,
+    /tenant_id\s*=\s*\(select\s+current_tenant_id\(\)\)/i,
+    /has_recent_privileged_step_up\('tenant_admin'\)/i,
+  ];
+
+  for (const predicate of requiredPredicates) {
+    if (!predicate.test(usingClause) || !predicate.test(withCheckClause)) {
+      throw new Error(
+        `${policyName} must enforce ${predicate} in both USING and WITH CHECK`,
+      );
+    }
+  }
+
+  const expectedClause = [
+    "(select current_user_role()) = 'tenant_admin'",
+    `${tableName}.tenant_id = (select current_tenant_id())`,
+    "(select has_recent_privileged_step_up('tenant_admin'))",
+  ].join(" and ");
+
+  if (
+    normalizeSql(usingClause) !== normalizeSql(expectedClause) ||
+    normalizeSql(withCheckClause) !== normalizeSql(expectedClause)
+  ) {
+    throw new Error(
+      `${policyName} must AND-connect only the tenant-admin, tenant, and step-up predicates in both USING and WITH CHECK`,
+    );
+  }
+};
+
+for (const policyName of [
+  "gear_admin_delete",
+  "gear_admin_insert",
+  "gear_admin_update",
+  "gear_tenant_user_update",
+  "student checkout gear",
+  "student_checkout_gear",
+  "student_gear_update",
+  "students_admin_delete",
+  "students_admin_insert",
+  "students_admin_update",
+]) {
+  requireDroppedOnly(policyName);
+}
+
+requireStepUpPolicy("tenant_admin_write_gear", "gear");
+requireStepUpPolicy("tenant_admin_write_students", "students");
+
+console.log("Privileged gear/student RLS policies require tenant-admin step-up.");

--- a/scripts/check-sql-function-coupling.mjs
+++ b/scripts/check-sql-function-coupling.mjs
@@ -33,11 +33,12 @@ const relatedFiles = changedFiles.filter(
     file.startsWith('supabase/functions/') ||
     file.startsWith('src/services/') ||
     file.startsWith('tests/') ||
-    file.startsWith('docs/api/')
+    file.startsWith('docs/api/') ||
+    file === 'scripts/check-privileged-rls-policies.mjs'
 );
 
 if (relatedFiles.length === 0) {
-  console.error('SQL changes were detected without any related Edge Function, service, test, or API contract updates.');
+  console.error('SQL changes were detected without any related Edge Function, service, test, verification, or API contract updates.');
   console.error('Changed SQL files:');
   for (const file of sqlFiles) console.error(`- ${file}`);
   process.exit(1);
@@ -45,4 +46,4 @@ if (relatedFiles.length === 0) {
 
 console.log('SQL/function coupling check passed.');
 console.log(`SQL files changed: ${sqlFiles.length}`);
-console.log(`Related function/service/test/contract files changed: ${relatedFiles.length}`);
+console.log(`Related function/service/test/verification/contract files changed: ${relatedFiles.length}`);

--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -25,6 +25,9 @@ if "${SEARCH[@]}" "sb_secret_|SUPABASE_SERVICE_ROLE_KEY=.+|CLOUDFLARE_API_TOKEN=
 fi
 echo "No private secret assignments found in .env.example."
 
+echo "[security] checking privileged RLS policy invariants"
+node ./scripts/check-privileged-rls-policies.mjs
+
 echo "[security] running Supabase shared security regression tests"
 deno test --allow-env \
   supabase/functions/_shared/cors_test.ts \

--- a/supabase/sql/z_rls_initplan_optimization.sql
+++ b/supabase/sql/z_rls_initplan_optimization.sql
@@ -20,53 +20,53 @@ drop policy if exists gear_read_tenant on public.gear;
 create policy gear_read_tenant on public.gear for select to public
   using (tenant_id = (select current_tenant_id()));
 
+-- All supported gear writes go through step-up-gated Edge Functions. Remove
+-- legacy direct-PostgREST policies so they cannot OR-bypass the canonical
+-- tenant-admin step-up policy below.
 drop policy if exists gear_admin_delete on public.gear;
-create policy gear_admin_delete on public.gear for delete to public
-  using ((select current_user_role()) = 'tenant_admin' and gear.tenant_id = (select current_tenant_id()));
-
 drop policy if exists gear_admin_insert on public.gear;
-create policy gear_admin_insert on public.gear for insert to public
-  with check ((select current_user_role()) = 'tenant_admin' and gear.tenant_id = (select current_tenant_id()));
-
 drop policy if exists gear_admin_update on public.gear;
-create policy gear_admin_update on public.gear for update to public
-  using ((select current_user_role()) = 'tenant_admin' and gear.tenant_id = (select current_tenant_id()));
-
 drop policy if exists gear_tenant_user_update on public.gear;
-create policy gear_tenant_user_update on public.gear for update to public
-  using ((select current_user_role()) = any (array['tenant_user','tenant_admin']) and gear.tenant_id = (select current_tenant_id()));
-
--- "student checkout gear" (with space) is an exact duplicate of
--- student_checkout_gear; drop the legacy spaced name, keep the canonical one.
 drop policy if exists "student checkout gear" on public.gear;
-
 drop policy if exists student_checkout_gear on public.gear;
-create policy student_checkout_gear on public.gear for update to public
-  using (exists (select 1 from students
-    where students.id = (select auth.uid()) and students.tenant_id = gear.tenant_id));
-
 drop policy if exists student_gear_update on public.gear;
-create policy student_gear_update on public.gear for update to public
-  using (exists (select 1 from students
-    where students.id = (select auth.uid()) and students.id = gear.checked_out_by))
-  with check (checked_out_by is null or checked_out_by = (select auth.uid()));
+
+drop policy if exists tenant_admin_write_gear on public.gear;
+create policy tenant_admin_write_gear on public.gear for all to authenticated
+  using (
+    (select current_user_role()) = 'tenant_admin'
+    and gear.tenant_id = (select current_tenant_id())
+    and (select has_recent_privileged_step_up('tenant_admin'))
+  )
+  with check (
+    (select current_user_role()) = 'tenant_admin'
+    and gear.tenant_id = (select current_tenant_id())
+    and (select has_recent_privileged_step_up('tenant_admin'))
+  );
 
 -- ============================ students ============================
 drop policy if exists students_read_tenant on public.students;
 create policy students_read_tenant on public.students for select to public
   using (tenant_id = (select current_tenant_id()));
 
+-- Remove the older per-command policies: permissive RLS policies are ORed, so
+-- retaining them would make the step-up predicate below optional.
 drop policy if exists students_admin_delete on public.students;
-create policy students_admin_delete on public.students for delete to public
-  using ((select current_user_role()) = 'tenant_admin' and students.tenant_id = (select current_tenant_id()));
-
 drop policy if exists students_admin_insert on public.students;
-create policy students_admin_insert on public.students for insert to public
-  with check ((select current_user_role()) = 'tenant_admin' and students.tenant_id = (select current_tenant_id()));
-
 drop policy if exists students_admin_update on public.students;
-create policy students_admin_update on public.students for update to public
-  using ((select current_user_role()) = 'tenant_admin' and students.tenant_id = (select current_tenant_id()));
+
+drop policy if exists tenant_admin_write_students on public.students;
+create policy tenant_admin_write_students on public.students for all to authenticated
+  using (
+    (select current_user_role()) = 'tenant_admin'
+    and students.tenant_id = (select current_tenant_id())
+    and (select has_recent_privileged_step_up('tenant_admin'))
+  )
+  with check (
+    (select current_user_role()) = 'tenant_admin'
+    and students.tenant_id = (select current_tenant_id())
+    and (select has_recent_privileged_step_up('tenant_admin'))
+  );
 
 -- ============================ gear_logs ============================
 drop policy if exists gear_logs_read_tenant on public.gear_logs;


### PR DESCRIPTION
This pull request implements a major security hardening for privileged RLS (Row-Level Security) policies on the `gear` and `students` tables. It removes legacy, permissive policies and replaces them with strict, unified policies that require a recent tenant-admin "step-up" for all privileged writes. Automated checks are also added to enforce these invariants in CI, and the security audit script is updated accordingly.

**Privileged RLS policy hardening:**

* [`supabase/sql/z_rls_initplan_optimization.sql`](diffhunk://#diff-eee633122e330c5fad5b0b1b5eddb69d3ae68155b86c05e1bc4591315f74a39fR23-R69): Removes legacy per-command RLS policies (e.g., `gear_admin_delete`, `students_admin_update`) that could be OR-bypassed, and replaces them with unified `tenant_admin_write_gear` and `tenant_admin_write_students` policies that require the user to be a tenant admin, match the tenant, and have a recent privileged step-up for all write operations.

**Automated verification:**

* [`scripts/check-privileged-rls-policies.mjs`](diffhunk://#diff-e29a94cddc6c44b0848910f820a7dcce7957b3666085724c2043a6b8004739b7R1-R123): Adds a script that parses the final migration SQL to ensure all legacy policies are dropped and the new step-up policies are present and correctly structured. It checks for strict AND-connected predicates in both USING and WITH CHECK clauses.
* [`scripts/security-audit.sh`](diffhunk://#diff-7be6f6a55faaf6f082b532f92d5df95968b56693f0890343ac03b1a8eaff9623R28-R30): Integrates the new RLS policy verification script into the security audit pipeline, ensuring policy invariants are enforced in CI.

**Developer workflow improvements:**

* [`scripts/check-sql-function-coupling.mjs`](diffhunk://#diff-feb7824e287ac6b5d696fd988daff8ce8840e3229f1dab3acdaf2f907045ed22L36-R49): Updates the SQL/function coupling check to recognize the new verification script as a valid related change, improving developer feedback for SQL changes.

**Other:**

* [`scripts/check-initial-load-budget.mjs`](diffhunk://#diff-57288082954212dd73ab76548e6d75c5a2b65164534e387a43ff6c068aed3d5dL3-R21): Refactors asset path resolution for improved security, ensuring asset reads are strictly contained within the assets directory. [[1]](diffhunk://#diff-57288082954212dd73ab76548e6d75c5a2b65164534e387a43ff6c068aed3d5dL3-R21) [[2]](diffhunk://#diff-57288082954212dd73ab76548e6d75c5a2b65164534e387a43ff6c068aed3d5dL51-R62)

These changes collectively ensure that only authenticated tenant-admins who have recently performed a privileged step-up can perform sensitive writes to `gear` and `students`, and that this invariant is continuously verified in CI.