### PR TITLE
Ignore TypeScript major updates and update changelog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     labels:
       - "dependencies"
     ignore:
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
       - dependency-name: "vue-router"
         update-types:
           - "version-update:semver-major"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ This changelog summarizes notable ItemTraxx product, reliability, security, and 
 Changes are dated based on the default timezone: America/Los_Angeles
 
 ---
+
+### 7/19/2026 Development Update
+
+- Documentation updates.
+
+### 7/18/2026 Development Update
+
+- fixed dependency maintenance and CI tooling updates.
+
 ### Attempted Distributed HTTP-Layer DDoS attack on ItemTraxx mitigated successfully
 
 


### PR DESCRIPTION
This pull request includes updates to dependency management and documentation. The main changes are:

Dependency management:

* Updated `.github/dependabot.yml` to ignore major version updates for the `typescript` dependency, preventing automatic PRs for breaking changes in TypeScript.

Documentation:

* Added new entries to `CHANGELOG.md` for 7/18/2026 and 7/19/2026, summarizing documentation updates and dependency/CI tooling maintenance.