### PR TITLE
ci: enforce staged promotion branch flow

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - preview
+      - staging
 
 concurrency:
   group: ci-core-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - preview
+      - staging
   pull_request:
   schedule:
     - cron: '21 9 * * 1'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - preview
+      - staging
 
 concurrency:
   group: e2e-${{ github.ref }}

--- a/.github/workflows/guard-dev-prs-to-main.yml
+++ b/.github/workflows/guard-dev-prs-to-main.yml
@@ -1,4 +1,4 @@
-name: Guard Dev PRs To Main
+name: Guard Promotion PR Flow
 
 permissions:
   contents: read
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches:
       - main
+      - preview
+      - staging
     types:
       - opened
       - reopened
@@ -28,8 +30,23 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "$BASE_REF" == "main" && "$HEAD_REF" == dev/* ]]; then
+          required_base=""
+
+          case "$HEAD_REF" in
+            dev/*)
+              required_base="staging"
+              ;;
+            staging)
+              required_base="preview"
+              ;;
+            preview)
+              required_base="main"
+              ;;
+          esac
+
+          if [[ -n "$required_base" && "$BASE_REF" != "$required_base" ]]; then
             echo "blocked=true" >> "$GITHUB_OUTPUT"
+            echo "required_base=$required_base" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -41,9 +58,9 @@ jobs:
         with:
           script: |
             const body = [
-              "<!-- itx-dev-pr-to-main-guard -->",
-              "Can't merge this PR into `main` from this branch.",
-              "This pull request cannot be merged into main. It must merge into preview before main. Change the base branch to preview."
+              "<!-- itx-promotion-pr-flow-guard -->",
+              "This pull request does not follow the required promotion path.",
+              `Change the base branch to \`${{ steps.guard.outputs.required_base }}\`: \`dev/* → staging → preview → main\`."
             ].join("\n\n");
 
             const { owner, repo } = context.repo;
@@ -57,7 +74,7 @@ jobs:
 
             const existing = comments.find((comment) =>
               comment.user?.type === "Bot" &&
-              comment.body?.includes("<!-- itx-dev-pr-to-main-guard -->")
+              comment.body?.includes("<!-- itx-promotion-pr-flow-guard -->")
             );
 
             if (existing) {
@@ -80,7 +97,7 @@ jobs:
       - name: Fail blocked PR
         if: ${{ steps.guard.outputs.blocked == 'true' }}
         run: |
-          echo "Pull requests from dev/* must target preview before main."
+          echo "This branch must target ${{ steps.guard.outputs.required_base }}. Required path: dev/* -> staging -> preview -> main."
           exit 1
 
       - name: Allow valid PR path

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - preview
+      - staging
 
 concurrency:
   group: security-audit-${{ github.ref }}

--- a/.github/workflows/strix-security.yml
+++ b/.github/workflows/strix-security.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - preview
   workflow_dispatch:
 
 concurrency:
@@ -15,12 +16,12 @@ concurrency:
 
 jobs:
   kill-switch-preflight:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.ref == 'preview' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.pull_request.base.ref == 'preview' && github.event.pull_request.head.ref == 'staging') || (github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'preview') }}
     uses: ./.github/workflows/kill-switch-preflight.yml
 
   strix-security-scan:
     needs: kill-switch-preflight
-    if: ${{ (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.ref == 'preview') && needs.kill-switch-preflight.outputs.active != 'true' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' || (github.event.pull_request.base.ref == 'preview' && github.event.pull_request.head.ref == 'staging') || (github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'preview')) && needs.kill-switch-preflight.outputs.active != 'true' }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Establishes the enforced promotion path: `dev/* → staging → preview → main`.

- Runs CI, E2E, CodeQL, and security audit on staging
- Blocks promotion PRs that skip a required stage