### PR TITLE
ci: handle zero diff base on branch creation

### DIFF
--- a/scripts/check-sql-function-coupling.mjs
+++ b/scripts/check-sql-function-coupling.mjs
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 
 function getChangedFiles(base, head) {
-  if (!base) return [];
+  if (!base || /^0+$/.test(base)) return [];
   const diffRange = head ? `${base}...${head}` : `${base}...HEAD`;
   const output = execFileSync('git', ['diff', '--name-only', diffRange], {
     encoding: 'utf8',


### PR DESCRIPTION
Handles GitHub's all-zero push base for a newly created branch so the SQL/function coupling check safely skips the empty diff.