### PR TITLE
Pin Node runtime and update allowed origins for Vercel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ VITE_PRIVACY_URL=
 # Local development example:
 # ITX_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:5174
 # Shared environment example:
-# ITX_ALLOWED_ORIGINS=https://itemtraxx.com,https://www.itemtraxx.com,https://status.itemtraxx.com,https://internal.itemtraxx.com,https://app.itemtraxx.com,https://itxdemo.app.itemtraxx.com,https://dennis.dev.itemtraxx.com,https://leo.dev.itemtraxx.com,https://testdist.app.itemtraxx.com,https://dev.itemtraxx.com,https://preview.itemtraxx.com
+# ITX_ALLOWED_ORIGINS=https://itemtraxx.com,https://www.itemtraxx.com,https://status.itemtraxx.com,https://internal.itemtraxx.com,https://app.itemtraxx.com,https://itxdemo.app.itemtraxx.com,https://dennis.dev.itemtraxx.com,https://leo.dev.itemtraxx.com,https://testdist.app.itemtraxx.com,https://dev.itemtraxx.com,https://preview.itemtraxx.com,https://staging.itemtraxx.com
 ITX_ALLOWED_ORIGINS=
 # VITE_TENANT_LOGIN_FUNCTION=tenant-login
 # VITE_LOGIN_NOTIFY_FUNCTION=login-notify

--- a/cloudflare/edge-proxy/src/constants.ts
+++ b/cloudflare/edge-proxy/src/constants.ts
@@ -38,4 +38,5 @@ export const DEFAULT_ALLOWED_ORIGINS = [
   "https://testdist.app.itemtraxx.com",
   "https://dev.itemtraxx.com",
   "https://preview.itemtraxx.com",
+  "https://staging.itemtraxx.com",
 ];

--- a/cloudflare/edge-proxy/wrangler.toml
+++ b/cloudflare/edge-proxy/wrangler.toml
@@ -6,7 +6,7 @@ preview_urls = false
 
 [vars]
 # Comma-separated origins allowed to call this proxy.
-ALLOWED_ORIGINS = "https://itemtraxx.com,https://www.itemtraxx.com,https://status.itemtraxx.com,https://internal.itemtraxx.com,https://app.itemtraxx.com,https://itxdemo.app.itemtraxx.com,https://dennis.dev.itemtraxx.com,https://leo.dev.itemtraxx.com,https://testdist.app.itemtraxx.com,https://dev.itemtraxx.com,https://preview.itemtraxx.com"
+ALLOWED_ORIGINS = "https://itemtraxx.com,https://www.itemtraxx.com,https://status.itemtraxx.com,https://internal.itemtraxx.com,https://app.itemtraxx.com,https://itxdemo.app.itemtraxx.com,https://dennis.dev.itemtraxx.com,https://leo.dev.itemtraxx.com,https://testdist.app.itemtraxx.com,https://dev.itemtraxx.com,https://preview.itemtraxx.com,https://staging.itemtraxx.com"
 TRUST_LOCAL_ORIGINS = "false"
 # Optional hard allowlist of function names (comma-separated).
 ALLOWED_FUNCTIONS = "tenant-login,checkoutReturn,checkout-borrower-lookup,admin-gear-mutate,admin-student-mutate,admin-ops,system-status,super-tenant-mutate,super-admin-mutate,super-dashboard,super-gear-mutate,super-student-mutate,super-logs-query,super-ops,district-dashboard,district-admin-mutate,contact-sales-submit,contact-support-submit,client-error-report,consent-record,job-worker,login-notify,super-auth-verify,district-handoff,tenant-admin-mutate,privileged-step-up"

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "wrangler": "4.107.1"
       },
       "engines": {
-        "node": "22.x"
+        "node": "24.x"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "wrangler": "4.107.1"
       },
       "engines": {
-        "node": ">=22.15.0"
+        "node": "22.x"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "engines": {
-    "node": "22.x"
+    "node": "24.x"
   },
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "engines": {
-    "node": ">=22.15.0"
+    "node": "22.x"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This pull request updates environment configuration and deployment files to add support for the `https://staging.itemtraxx.com` origin and bumps the minimum required Node.js version. The most important changes are:

**Allowed Origins Update:**

* Added `https://staging.itemtraxx.com` to the list of allowed origins in `.env.example`, `cloudflare/edge-proxy/src/constants.ts`, and `cloudflare/edge-proxy/wrangler.toml` to enable requests from the staging environment. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL26-R26) [[2]](diffhunk://#diff-3ee116637e2c9ee641b64bd7c752b8972b2050d69f85d411822fe66b828c7e2bR41) [[3]](diffhunk://#diff-35271902889d9cb51873d1f429038399c53fb96c398a462336e3f94bfecc810eL9-R9)

**Node.js Version Requirement:**

* Updated the required Node.js version in `package.json` from `>=22.15.0` to `24.x` to ensure compatibility with the latest features and security updates.