### PR TITLE
Fix Tenant Account setup and password recovery

### DIFF
--- a/src/pages/ResetPassword.vue
+++ b/src/pages/ResetPassword.vue
@@ -25,8 +25,12 @@
             type="password"
             placeholder="Enter new password"
             autocomplete="new-password"
+            aria-describedby="new-password-requirements"
           />
         </label>
+        <small id="new-password-requirements" class="password-hint">
+          Use at least 12 characters with lowercase, uppercase, a number, and a symbol.
+        </small>
         <label>
           Confirm Password
           <input
@@ -76,6 +80,33 @@ const hasRecoveryLinkContext = () => {
   return queryParams.get("type") === "recovery" || hashParams.get("type") === "recovery";
 };
 
+const passwordPolicyMessage =
+  "Password must be at least 12 characters and include lowercase, uppercase, a number, and a symbol.";
+
+const meetsPasswordPolicy = (value: string) =>
+  value.length >= 12 &&
+  /[a-z]/.test(value) &&
+  /[A-Z]/.test(value) &&
+  /[0-9]/.test(value) &&
+  /[^A-Za-z0-9]/.test(value);
+
+const passwordUpdateErrorMessage = (cause: unknown) => {
+  if (!cause || typeof cause !== "object") {
+    return "Unable to update password. Please try again. If the issue persists, contact support.";
+  }
+  const authError = cause as { code?: unknown; name?: unknown };
+  if (authError.code === "weak_password" || authError.name === "AuthWeakPasswordError") {
+    return passwordPolicyMessage;
+  }
+  if (authError.code === "same_password") {
+    return "New password must be different from your current password.";
+  }
+  if (["bad_jwt", "session_not_found", "otp_expired"].includes(String(authError.code))) {
+    return "Invalid or expired reset link. Request a new reset email.";
+  }
+  return "Unable to update password. Please try again. If the issue persists, contact support.";
+};
+
 const showBlockedState = computed(
   () => hasCheckedRecoverySession.value && !isReady.value && !success.value
 );
@@ -112,8 +143,8 @@ const handleReset = async () => {
     error.value = "Invalid or expired reset link. Request a new reset email.";
     return;
   }
-  if (newPassword.value.length < 8) {
-    error.value = "Password must be at least 8 characters.";
+  if (!meetsPasswordPolicy(newPassword.value)) {
+    error.value = passwordPolicyMessage;
     return;
   }
   if (newPassword.value !== confirmPassword.value) {
@@ -127,7 +158,7 @@ const handleReset = async () => {
       password: newPassword.value,
     });
     if (updateError) {
-      error.value = "Unable to update password. Request a new reset link and try again. If the issue persists, contact support.";
+      error.value = passwordUpdateErrorMessage(updateError);
       return;
     }
     success.value = true;
@@ -222,6 +253,13 @@ onUnmounted(() => {
   border-color: var(--reset-border);
   background: var(--reset-input-bg);
   color: var(--reset-text);
+}
+
+.password-hint {
+  display: block;
+  margin-top: 0.45rem;
+  color: var(--reset-muted);
+  font-weight: 400;
 }
 
 .reset-form .button-primary {

--- a/src/pages/super/TenantAccounts.vue
+++ b/src/pages/super/TenantAccounts.vue
@@ -39,7 +39,7 @@
             <td>{{ account.workspace_name }}</td>
             <td>{{ account.is_active ? 'Active' : 'Suspended' }}</td>
             <td class="row-actions">
-              <button @click="saveEmail(account)">Save email</button>
+              <button :disabled="saving || emailUnchanged(account)" @click="saveEmail(account)">Save email</button>
               <button @click="toggle(account)">{{ account.is_active ? 'Suspend' : 'Restore' }}</button>
               <button @click="reset(account)">Reset password</button>
               <button @click="remove(account)">Remove</button>
@@ -76,6 +76,11 @@ const loading = ref(false);
 const saving = ref(false);
 const message = ref("");
 const error = ref("");
+const savedEmails = ref<Record<string, string>>({});
+
+const normalizeEmail = (value: string) => value.trim().toLowerCase();
+const emailUnchanged = (account: SuperTenantAccount) =>
+  normalizeEmail(account.auth_email) === savedEmails.value[account.id];
 
 const run = async (operation: () => Promise<void>) => {
   saving.value = true;
@@ -88,7 +93,12 @@ const run = async (operation: () => Promise<void>) => {
 const load = async () => {
   loading.value = true;
   error.value = "";
-  try { accounts.value = await listTenantAccounts(search.value, workspaceId.value); }
+  try {
+    accounts.value = await listTenantAccounts(search.value, workspaceId.value);
+    savedEmails.value = Object.fromEntries(
+      accounts.value.map((account) => [account.id, normalizeEmail(account.auth_email)]),
+    );
+  }
   catch (cause) { error.value = cause instanceof Error ? cause.message : "Unable to load Tenant Accounts."; }
   finally { loading.value = false; }
 };

--- a/supabase/functions/super-admin-mutate/tenantAccounts.ts
+++ b/supabase/functions/super-admin-mutate/tenantAccounts.ts
@@ -96,6 +96,9 @@ export const handleTenantAccountAction = async (
 
   if (action === "update_tenant_account_email") {
     const email = requireEmail(payload.auth_email);
+    if (email === target.auth_email.toLowerCase()) {
+      return { handled: true, status: 200, data: target };
+    }
     const updated = await repository.updateEmail(id, email);
     await repository.audit(action, id, { auth_email: email });
     return { handled: true, status: 200, data: updated };

--- a/supabase/functions/super-admin-mutate/tenantAccounts_test.ts
+++ b/supabase/functions/super-admin-mutate/tenantAccounts_test.ts
@@ -25,7 +25,10 @@ const makeRepository = () => {
     create: async (workspaceId, email) => ({ ...account, workspace_id: workspaceId, auth_email: email }),
     findActive: async () => account,
     setStatus: async (_id, isActive) => ({ ...account, is_active: isActive }),
-    updateEmail: async (_id, email) => ({ ...account, auth_email: email }),
+    updateEmail: async (id, email) => {
+      calls.push({ name: "updateEmail", value: { id, email } });
+      return { ...account, auth_email: email };
+    },
     sendReset: async (email) => { calls.push({ name: "sendReset", value: email }); },
     softDelete: async (id, at) => { calls.push({ name: "softDelete", value: { id, at } }); },
     revokeSessions: async (id, actorId, at) => { calls.push({ name: "revokeSessions", value: { id, actorId, at } }); },
@@ -55,6 +58,21 @@ Deno.test("Super Admin Tenant Account creation requires an explicit workspace", 
     Error,
     "Invalid request",
   );
+});
+
+Deno.test("saving an unchanged Tenant Account email preserves the active setup link", async () => {
+  const { repository, calls } = makeRepository();
+  const result = await handleTenantAccountAction("update_tenant_account_email", {
+    id: account.id,
+    auth_email: "  DESK@example.test ",
+  }, {
+    actorId: "30000000-0000-4000-8000-000000000001",
+    now: () => "2026-07-25T01:00:00.000Z",
+    repository,
+  });
+
+  assertEquals(result, { handled: true, status: 200, data: account });
+  assertEquals(calls, []);
 });
 
 Deno.test("Super Admin Tenant Account removal soft-deletes and revokes every active session", async () => {

--- a/tests/e2e/password-recovery.spec.ts
+++ b/tests/e2e/password-recovery.spec.ts
@@ -150,8 +150,8 @@ test.describe("password recovery", () => {
 
     await navigateApp(page, "/reset-password?type=recovery");
     await expect(page.getByRole("button", { name: "Update Password" })).toBeEnabled();
-    await page.getByLabel("New Password", { exact: true }).fill("new-password-123");
-    await page.getByLabel("Confirm Password").fill("new-password-123");
+    await page.getByLabel("New Password", { exact: true }).fill("New-password-123!");
+    await page.getByLabel("Confirm Password").fill("New-password-123!");
     await page.getByRole("button", { name: "Update Password" }).click();
 
     await expect(page.getByText("Password successfully updated.")).toBeVisible();
@@ -164,8 +164,99 @@ test.describe("password recovery", () => {
       )
       .toEqual([
         { method: "getSession" },
-        { method: "updateUser", payload: { password: "new-password-123" } },
+        { method: "updateUser", payload: { password: "New-password-123!" } },
         { method: "signOut", payload: { scope: "local" } },
       ]);
+  });
+
+  test("reset-password explains password policy failures without blaming the recovery link", async ({
+    page,
+  }) => {
+    await openPublicShell(page);
+    await page.evaluate(async () => {
+      const { supabase } = await import("/src/services/supabaseClient.ts");
+      Object.defineProperty(supabase.auth, "getSession", {
+        configurable: true,
+        value: async () => ({
+          data: {
+            session: {
+              access_token: "recovery-access-token",
+              refresh_token: "recovery-refresh-token",
+              expires_in: 3600,
+              expires_at: Math.floor(Date.now() / 1000) + 3600,
+              token_type: "bearer",
+              user: {
+                id: "recovery-user",
+                aud: "authenticated",
+                role: "authenticated",
+                email: "person@example.com",
+                app_metadata: {},
+                user_metadata: {},
+                identities: [],
+                created_at: new Date().toISOString(),
+              },
+            },
+          },
+          error: null,
+        }),
+      });
+      Object.defineProperty(supabase.auth, "updateUser", {
+        configurable: true,
+        value: async () => ({
+          data: { user: null },
+          error: {
+            name: "AuthWeakPasswordError",
+            message: "Password should contain at least one character of each: abc, ABC, 123, symbols",
+            status: 422,
+            code: "weak_password",
+            reasons: ["characters"],
+          },
+        }),
+      });
+    });
+
+    await navigateApp(page, "/reset-password?type=recovery");
+    await page.getByLabel("New Password", { exact: true }).fill("ValidLength1!");
+    await page.getByLabel("Confirm Password").fill("ValidLength1!");
+    await page.getByRole("button", { name: "Update Password" }).click();
+
+    await expect(page.getByText(
+      "Password must be at least 12 characters and include lowercase, uppercase, a number, and a symbol.",
+    )).toBeVisible();
+    await expect(page.getByText(/Request a new reset link/)).toHaveCount(0);
+  });
+
+  test("reset-password rejects passwords that do not meet the configured policy before submission", async ({
+    page,
+  }) => {
+    await openPublicShell(page);
+    await page.evaluate(async () => {
+      const { supabase } = await import("/src/services/supabaseClient.ts");
+      const calls: unknown[] = [];
+      (window as unknown as { __passwordPolicyCalls: unknown[] }).__passwordPolicyCalls = calls;
+      Object.defineProperty(supabase.auth, "getSession", {
+        configurable: true,
+        value: async () => ({ data: { session: { access_token: "recovery-access-token" } }, error: null }),
+      });
+      Object.defineProperty(supabase.auth, "updateUser", {
+        configurable: true,
+        value: async (payload: unknown) => {
+          calls.push(payload);
+          return { data: { user: null }, error: null };
+        },
+      });
+    });
+
+    await navigateApp(page, "/reset-password?type=recovery");
+    await page.getByLabel("New Password", { exact: true }).fill("alllowercasepassword");
+    await page.getByLabel("Confirm Password").fill("alllowercasepassword");
+    await page.getByRole("button", { name: "Update Password" }).click();
+
+    await expect(page.getByText(
+      "Password must be at least 12 characters and include lowercase, uppercase, a number, and a symbol.",
+    )).toBeVisible();
+    await expect.poll(() => page.evaluate(
+      () => (window as unknown as { __passwordPolicyCalls: unknown[] }).__passwordPolicyCalls,
+    )).toEqual([]);
   });
 });

--- a/tests/e2e/workspace-model.spec.ts
+++ b/tests/e2e/workspace-model.spec.ts
@@ -147,7 +147,12 @@ test.describe("workspace model role surfaces", () => {
     await navigateApp(page, "/super-admin/tenant-accounts");
 
     await expect(page.getByRole("heading", { name: "Tenant Accounts" })).toBeVisible();
-    await expect(page.getByRole("textbox", { name: "Email for Demo Tenant" })).toHaveValue("desk@demo.test");
+    const emailInput = page.getByRole("textbox", { name: "Email for Demo Tenant" });
+    const saveEmail = page.getByRole("button", { name: "Save email" });
+    await expect(emailInput).toHaveValue("desk@demo.test");
+    await expect(saveEmail).toBeDisabled();
+    await emailInput.fill("new-desk@demo.test");
+    await expect(saveEmail).toBeEnabled();
     await page.getByRole("button", { name: "Suspend" }).click();
     await expect.poll(() => actions).toContain("set_tenant_account_status");
   });


### PR DESCRIPTION
## Summary
- prevent unchanged Tenant Account email saves from invalidating one-time setup links
- disable unchanged email saves in the Super Admin UI
- enforce and explain the 12-character mixed-character password policy on recovery
- map Supabase weak-password and expired-session errors to actionable messages

## Root cause
Production auth logs showed the setup recovery token was issued, then an unchanged email update touched the Auth user and invalidated that token. The second recovery session was accepted, but Supabase rejected the submitted password with 422 while the UI hid the policy reason behind a generic expired-link message.

## Verification
- `npm run test:e2e` (117 passed, 1 skipped)
- `npm run build`
- `npm run security:gate`
- `deno check supabase/functions/super-admin-mutate/index.ts`
- focused Deno Tenant Account suite (5 passed)
- bundle, CSS, edge-contract, coverage, and SQL-coupling checks