### PR TITLE
fix: register account session on destination origin, not before redirect

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -205,7 +205,12 @@ const isWorkspaceScopedRoute = computed(() =>
   ),
 );
 const isWorkspaceAdminArea = computed(() => route.path !== "/admin/login" && route.path.startsWith("/admin"));
-const shouldTrackAccountSession = computed(() => auth.isAuthenticated && auth.role === "workspace_admin" && isWorkspaceAdminArea.value);
+const shouldTrackAccountSession = computed(() => {
+  if (!auth.isAuthenticated) return false;
+  if (auth.role === "workspace_admin") return isWorkspaceAdminArea.value;
+  if (auth.role === "tenant_account") return isWorkspaceScopedRoute.value;
+  return false;
+});
 const showNotificationBell = computed(() => auth.isAuthenticated && auth.role === "workspace_admin" && route.path !== "/admin/login" && route.path.startsWith("/admin"));
 const isUnavailableBypass = computed(() => isUnavailableBypassHost(window.location.hostname));
 

--- a/src/services/auth/workspaceLogin.ts
+++ b/src/services/auth/workspaceLogin.ts
@@ -2,8 +2,6 @@ import { invokeEdgeFunction } from "../edgeFunctionClient";
 import { getWorkspaceState } from "../../store/workspaceState";
 import { getAuthState, setWorkspaceContext } from "../../store/authState";
 import { exchangeHttpSession, fetchHttpSessionSummary } from "../httpSessionService";
-import { rotateDeviceSession } from "../../utils/deviceSession";
-import { touchAccountSession } from "../adminOpsService";
 import { applyHttpSessionSummary, resolveWorkspaceSlug } from "./sessionBootstrap";
 import { normalizeFunctionTarget, type LoginNotificationLocation } from "./types";
 const loginFunction=()=>normalizeFunctionTarget(import.meta.env.VITE_WORKSPACE_LOGIN_FUNCTION,"workspace-login");
@@ -16,7 +14,6 @@ export const workspaceLogin=async(email:string,password:string,turnstileToken?:s
   if(!result.data?.access_token||!result.data.refresh_token)throw new Error("Invalid email or password.");
   const summary=await exchangeHttpSession({access_token:result.data.access_token,refresh_token:result.data.refresh_token}).catch(()=>fetchHttpSessionSummary());
   await applyHttpSessionSummary(summary); const current=getAuthState(); setWorkspaceContext(current.sessionWorkspaceId);
-  if(current.role!=="super_admin"){rotateDeviceSession();await touchAccountSession({loginMethod:"password",loginLocation:current.role==="workspace_admin"?"admin_login":"regular_login"}).catch(()=>undefined);}
   sendLoginNotification(result.data.access_token,{loginLocation:current.role==="workspace_admin"?"workspace_admin_login":"account_login"});
   return {workspaceId:current.workspaceContextId,workspaceSlug:result.data.workspace_slug??await resolveWorkspaceSlug(current.workspaceContextId),role:current.role};
 };


### PR DESCRIPTION
device_id lives in localStorage, which does not carry across the root-domain -> workspace-subdomain login redirect. Touching the account_sessions row before that redirect bound it to a device_id the destination origin never sees, so every later device-bound check (checkoutReturn, admin-ops validate_session) failed and the router guard rendered a silent 404 instead of the checkout/admin page.

Drop the pre-redirect touch/rotate in workspaceLogin and let the existing post-mount session tracking (touch + validate) register the session using the destination origin's own device_id. Extend that tracking to tenant_account (previously workspace_admin only) so tenants get the same self-healing registration admins already had.