### PR TITLE
Post-migration UI cleanup

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -61,17 +61,10 @@
       :is-outdated="isOutdated"
       :menu-open="menuOpen"
       :theme-label="themeLabel"
-      :can-replay-onboarding="onboarding.canReplay.value"
+      :show-account-panel="showAccountPanel"
       :show-logout-user-action="showLogoutUserAction"
-      :app-version="appVersion"
-      :offline-queue-count="offlineQueue.count.value"
-      :offline-queue-tooltip="offlineQueue.tooltip.value"
-      :status-class="statusClass"
-      :status-label="statusLabel"
       @toggle-menu="toggleMenu"
       @toggle-theme="toggleTheme"
-      @open-admin-panel="openAdminPanel"
-      @open-onboarding="openOnboardingTour"
       @logout="logoutTenant"
       @close-menu="menuOpen = false"
     />
@@ -96,6 +89,7 @@
       @save-preferences="consent.savePreferences"
     />
     <FatalErrorToast v-if="fatalErrorToast.visible" />
+    <OfflineQueueToast :count="offlineQueue.count.value" :tooltip="offlineQueue.tooltip.value" />
     <Analytics v-if="consent.showTelemetry.value" />
     <SpeedInsights v-if="consent.showTelemetry.value" />
   </div>
@@ -126,6 +120,7 @@ import { getSessionTerminationState } from "./store/sessionTermination";
 const OnboardingModal = defineAsyncComponent(() => import("./components/OnboardingModal.vue"));
 const Analytics = defineAsyncComponent(async () => (await import("@vercel/analytics/vue")).Analytics);
 const FatalErrorToast = defineAsyncComponent(async () => (await import("./components/FatalErrorToast.vue")).default);
+const OfflineQueueToast = defineAsyncComponent(async () => (await import("./components/OfflineQueueToast.vue")).default);
 const SpeedInsights = defineAsyncComponent(async () => (await import("@vercel/speed-insights/vue")).SpeedInsights);
 
 const auth = getAuthState();
@@ -133,7 +128,7 @@ const district = getWorkspaceState();
 const routeLoading = getRouteLoadingState();
 const fatalErrorToast = getFatalErrorToastState();
 const sessionTermination = getSessionTerminationState();
-const { state: systemStatus, statusLabel, statusClass } = useSystemStatus();
+const { state: systemStatus } = useSystemStatus();
 const router = useRouter();
 const route = useRoute();
 const menuOpen = ref(false);
@@ -269,8 +264,7 @@ const applyTheme = (next: "light" | "dark") => {
 const toggleTheme = () => { applyTheme(theme.value === "dark" ? "light" : "dark"); menuOpen.value = false; };
 const toggleMenu = () => { menuOpen.value = !menuOpen.value; };
 const reloadApp = () => window.location.assign(`${window.location.origin}/`);
-const openOnboardingTour = () => { onboarding.open(); menuOpen.value = false; };
-const openAdminPanel = async () => { menuOpen.value = false; await router.push("/admin/login"); };
+const showAccountPanel = computed(() => auth.role === "tenant_account");
 const logoutTenant = async () => {
   if (!window.confirm("Are you sure you want to log out?")) return;
   menuOpen.value = false;

--- a/src/components/OfflineQueueToast.vue
+++ b/src/components/OfflineQueueToast.vue
@@ -1,0 +1,13 @@
+<template>
+  <div v-if="count > 0" class="toast toast-persist toast-bottom-left" :title="tooltip">
+    <div class="toast-title">Offline Queue</div>
+    <div class="toast-body">{{ count }} checkout{{ count === 1 ? "" : "s" }} waiting to sync.</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  count: number;
+  tooltip: string;
+}>();
+</script>

--- a/src/components/OnboardingModal.vue
+++ b/src/components/OnboardingModal.vue
@@ -97,7 +97,7 @@ const tenantUserSteps: OnboardingStep[] = [
   },
   {
     title: "Need help later?",
-    body: "Open the top-right menu any time and select 'Take tour' to replay these steps. If you need help or have questions, contact ItemTraxx support by clicking the menu in the top right and then 'Contact Support'.",
+    body: "If you need help or have questions, contact ItemTraxx support.",
   },
 ];
 
@@ -119,8 +119,8 @@ const workspaceAdminSteps: OnboardingStep[] = [
     body: "Use Settings for device sessions, notification policies, and other security-sensitive controls.",
   },
   {
-    title: "Support and replay",
-    body: "From the top-right menu, use 'Take tour' to replay onboarding. If you need help or have questions, contact ItemTraxx support by clicking the menu in the top right and then 'Contact Support'.",
+    title: "Support",
+    body: "If you need help or have questions, contact ItemTraxx support.",
   },
 ];
 

--- a/src/components/PublicFooter.vue
+++ b/src/components/PublicFooter.vue
@@ -22,7 +22,6 @@
       <div class="footer-column">
         <p class="footer-heading">Product</p>
         <RouterLink to="/login">Login</RouterLink>
-        <RouterLink to="/admin/login">Admin Login</RouterLink>
         <RouterLink to="/pricing">Pricing</RouterLink>
         <RouterLink to="/contact-sales">Contact Sales</RouterLink>
         <RouterLink to="/request-demo">Request Demo</RouterLink>

--- a/src/components/app/AuthenticatedNavigation.vue
+++ b/src/components/app/AuthenticatedNavigation.vue
@@ -23,18 +23,15 @@
       <button type="button" class="menu-item" role="menuitem" @click="emit('toggleTheme')">
         {{ themeLabel }}
       </button>
-      <button type="button" class="menu-item" role="menuitem" @click="emit('openAdminPanel')">
-        Open Admin Panel
-      </button>
-      <button
-        v-if="canReplayOnboarding"
-        type="button"
+      <RouterLink
+        v-if="showAccountPanel"
         class="menu-item"
         role="menuitem"
-        @click="emit('openOnboarding')"
+        to="/account"
+        @click="emit('closeMenu')"
       >
-        Take tour again
-      </button>
+        My Account
+      </RouterLink>
       <button
         v-if="showLogoutUserAction"
         type="button"
@@ -44,34 +41,13 @@
       >
         Log Out User
       </button>
-      <a class="menu-item muted" role="menuitem" href="/changelog" @click="emit('closeMenu')">
-        Version: <strong>{{ appVersion }}</strong>
-      </a>
-      <div v-if="isOutdated" class="menu-item status-warning" role="menuitem">
-        Version outdated, refresh to update.
-      </div>
-      <RouterLink class="menu-item" role="menuitem" to="/contact-support" @click="emit('closeMenu')">
-        Contact Support
-      </RouterLink>
-      <div class="menu-item muted menu-offline-queue" role="menuitem" :title="offlineQueueTooltip">
-        Offline Queue: {{ offlineQueueCount }}
-      </div>
-      <a
-        class="menu-item muted menu-status"
-        role="menuitem"
-        href="https://status.itemtraxx.com/?ref=trmenu"
-        target="_blank"
-        rel="noreferrer"
-      >
-        <span class="status-dot" :class="statusClass" aria-hidden="true"></span>
-        System Status: {{ statusLabel }}
-      </a>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { defineAsyncComponent } from "vue";
+import { RouterLink } from "vue-router";
 
 const NotificationBell = defineAsyncComponent(async () => {
   const module = await import("../NotificationBell.vue");
@@ -84,20 +60,13 @@ defineProps<{
   isOutdated: boolean;
   menuOpen: boolean;
   themeLabel: string;
-  canReplayOnboarding: boolean;
+  showAccountPanel: boolean;
   showLogoutUserAction: boolean;
-  appVersion: string;
-  offlineQueueCount: number;
-  offlineQueueTooltip: string;
-  statusClass: string;
-  statusLabel: string;
 }>();
 
 const emit = defineEmits<{
   toggleMenu: [];
   toggleTheme: [];
-  openAdminPanel: [];
-  openOnboarding: [];
   logout: [];
   closeMenu: [];
 }>();

--- a/src/components/app/TenantAccessPicker.vue
+++ b/src/components/app/TenantAccessPicker.vue
@@ -1,0 +1,142 @@
+<template>
+  <fieldset class="access-picker">
+    <legend>Tenant Account access</legend>
+    <div class="access-mode-toggle" role="group" aria-label="Tenant account access mode">
+      <button
+        type="button"
+        class="access-mode-option"
+        :class="{ active: accessMode === 'all' }"
+        :aria-pressed="accessMode === 'all'"
+        @click="setMode('all')"
+      >
+        All Tenant Accounts
+      </button>
+      <button
+        type="button"
+        class="access-mode-option"
+        :class="{ active: accessMode === 'restricted' }"
+        :aria-pressed="accessMode === 'restricted'"
+        @click="setMode('restricted')"
+      >
+        Specific Tenant Accounts
+      </button>
+    </div>
+
+    <div v-if="accessMode === 'restricted'" class="access-chip-list">
+      <p v-if="accounts.length === 0" class="muted access-chip-empty">No tenant accounts available.</p>
+      <button
+        v-for="account in accounts"
+        :key="account.id"
+        type="button"
+        class="access-chip"
+        :class="{ selected: selectedIds.includes(account.id) }"
+        :aria-pressed="selectedIds.includes(account.id)"
+        @click="toggleAccount(account.id)"
+      >
+        <span class="access-chip-check" aria-hidden="true"></span>
+        {{ account.auth_email }}
+      </button>
+    </div>
+  </fieldset>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  accessMode: "" | "all" | "restricted";
+  selectedIds: string[];
+  accounts: Array<{ id: string; auth_email: string }>;
+}>();
+
+const emit = defineEmits<{
+  "update:accessMode": ["" | "all" | "restricted"];
+  "update:selectedIds": [string[]];
+}>();
+
+const setMode = (mode: "all" | "restricted") => {
+  emit("update:accessMode", mode);
+  if (mode === "all") emit("update:selectedIds", []);
+};
+
+const toggleAccount = (id: string) => {
+  const next = props.selectedIds.includes(id)
+    ? props.selectedIds.filter((existing) => existing !== id)
+    : [...props.selectedIds, id];
+  emit("update:selectedIds", next);
+};
+</script>
+
+<style scoped>
+.access-picker {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.9rem 1rem 1rem;
+}
+
+.access-picker legend {
+  font-weight: 600;
+  padding: 0 0.3rem;
+}
+
+.access-mode-toggle {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.access-mode-option {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: var(--surface-2);
+  color: var(--muted);
+}
+
+.access-mode-option.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.access-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.85rem;
+}
+
+.access-chip-empty {
+  margin: 0;
+}
+
+.access-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.32rem 0.75rem 0.32rem 0.55rem;
+  font-size: 0.82rem;
+  background: var(--surface);
+}
+
+.access-chip-check {
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: transparent;
+  flex-shrink: 0;
+}
+
+.access-chip.selected {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+.access-chip.selected .access-chip-check {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+</style>

--- a/src/pages/workspace/Account.vue
+++ b/src/pages/workspace/Account.vue
@@ -1,0 +1,184 @@
+<template>
+  <main class="page">
+    <header>
+      <h1>My Account</h1>
+      <nav>
+        <RouterLink to="/checkout">Checkout</RouterLink> ·
+        <RouterLink to="/items">Items</RouterLink> ·
+        <RouterLink to="/borrowers">Borrowers</RouterLink> ·
+        <RouterLink to="/settings">Settings</RouterLink>
+      </nav>
+    </header>
+
+    <section>
+      <h2>Borrowers</h2>
+      <p v-if="borrowersLoading">Loading…</p>
+      <p v-else-if="borrowersError" class="error">{{ borrowersError }}</p>
+      <template v-else>
+        <table>
+          <thead>
+            <tr>
+              <th>Username</th>
+              <th>Borrower ID</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="borrower in pagedBorrowers" :key="borrower.id">
+              <td>{{ borrower.username }}</td>
+              <td>{{ borrower.borrower_id }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="account-pagination">
+          <button type="button" :disabled="borrowerPage === 0" @click="borrowerPage--">‹ Previous 20</button>
+          <span>{{ borrowerPageLabel }}</span>
+          <button type="button" :disabled="!hasMoreBorrowers" @click="borrowerPage++">Next 20 ›</button>
+        </div>
+      </template>
+    </section>
+
+    <section>
+      <h2>Items</h2>
+      <p v-if="itemsLoading">Loading…</p>
+      <p v-else-if="itemsError" class="error">{{ itemsError }}</p>
+      <template v-else>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Barcode</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="item in pagedItems" :key="item.id">
+              <td>{{ item.name }}</td>
+              <td>{{ item.barcode }}</td>
+              <td>{{ item.status }}</td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="account-pagination">
+          <button type="button" :disabled="itemPage === 0" @click="itemPage--">‹ Previous 20</button>
+          <span>{{ itemPageLabel }}</span>
+          <button type="button" :disabled="!hasMoreItems" @click="itemPage++">Next 20 ›</button>
+        </div>
+      </template>
+    </section>
+
+    <section>
+      <h2>Signed-in devices</h2>
+      <button type="button" @click="loadSessions">Refresh</button>
+      <ul>
+        <li v-for="session in sessions" :key="session.id">
+          <strong>{{ session.device_label || "Unknown device" }}</strong>
+          — last used {{ new Date(session.last_seen_at).toLocaleString() }}
+          <span v-if="session.is_current">(current)</span>
+          <button type="button" @click="revokeSession(session.id)">Revoke</button>
+        </li>
+      </ul>
+    </section>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import { RouterLink } from "vue-router";
+import { authenticatedSelect } from "../../services/authenticatedDataClient";
+import {
+  listAccountSessions,
+  revokeAccountSession,
+  type AccountSessionItem,
+} from "../../services/adminOpsService";
+
+const PAGE_SIZE = 20;
+
+type BorrowerRow = { id: string; username: string; borrower_id: string };
+type ItemRow = { id: string; name: string; barcode: string; status: string };
+
+const borrowers = ref<BorrowerRow[]>([]);
+const borrowersLoading = ref(true);
+const borrowersError = ref("");
+const borrowerPage = ref(0);
+
+const items = ref<ItemRow[]>([]);
+const itemsLoading = ref(true);
+const itemsError = ref("");
+const itemPage = ref(0);
+
+const sessions = ref<AccountSessionItem[]>([]);
+
+const pagedBorrowers = computed(() =>
+  borrowers.value.slice(borrowerPage.value * PAGE_SIZE, (borrowerPage.value + 1) * PAGE_SIZE),
+);
+const hasMoreBorrowers = computed(() => (borrowerPage.value + 1) * PAGE_SIZE < borrowers.value.length);
+const borrowerPageLabel = computed(() => {
+  if (!borrowers.value.length) return "No borrowers";
+  const start = borrowerPage.value * PAGE_SIZE + 1;
+  const end = Math.min(borrowers.value.length, (borrowerPage.value + 1) * PAGE_SIZE);
+  return `${start}–${end} of ${borrowers.value.length}`;
+});
+
+const pagedItems = computed(() =>
+  items.value.slice(itemPage.value * PAGE_SIZE, (itemPage.value + 1) * PAGE_SIZE),
+);
+const hasMoreItems = computed(() => (itemPage.value + 1) * PAGE_SIZE < items.value.length);
+const itemPageLabel = computed(() => {
+  if (!items.value.length) return "No items";
+  const start = itemPage.value * PAGE_SIZE + 1;
+  const end = Math.min(items.value.length, (itemPage.value + 1) * PAGE_SIZE);
+  return `${start}–${end} of ${items.value.length}`;
+});
+
+const loadBorrowers = async () => {
+  try {
+    borrowers.value = await authenticatedSelect<BorrowerRow[]>("borrowers", {
+      select: "id,username,borrower_id",
+      deleted_at: "is.null",
+      order: "username.asc",
+    });
+  } catch {
+    borrowersError.value = "Unable to load borrowers.";
+  } finally {
+    borrowersLoading.value = false;
+  }
+};
+
+const loadItems = async () => {
+  try {
+    items.value = await authenticatedSelect<ItemRow[]>("items", {
+      select: "id,name,barcode,status",
+      deleted_at: "is.null",
+      order: "name.asc",
+    });
+  } catch {
+    itemsError.value = "Unable to load items.";
+  } finally {
+    itemsLoading.value = false;
+  }
+};
+
+const loadSessions = async () => {
+  sessions.value = (await listAccountSessions()).sessions;
+};
+
+const revokeSession = async (id: string) => {
+  await revokeAccountSession(id);
+  await loadSessions();
+};
+
+onMounted(() => {
+  void loadBorrowers();
+  void loadItems();
+  void loadSessions();
+});
+</script>
+
+<style scoped>
+.account-pagination {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.6rem;
+}
+</style>

--- a/src/pages/workspace/admin/Accounts.vue
+++ b/src/pages/workspace/admin/Accounts.vue
@@ -1,2 +1,124 @@
-<template><main class="page admin-shell"><RouterLink to="/admin">Return to admin panel</RouterLink><h1>Tenant Accounts</h1><section class="card"><h2>Add Tenant Account</h2><form @submit.prevent="create"><input v-model="email" type="email" autocomplete="email" placeholder="Email address" required/><button :disabled="busy">Create and send setup link</button></form><p v-if="message">{{message}}</p></section><section class="card"><h2>Accounts</h2><table><thead><tr><th>Email</th><th>Status</th><th>Actions</th></tr></thead><tbody><tr v-for="account in accounts" :key="account.id"><td>{{account.auth_email}}</td><td>{{account.is_active?'Active':'Suspended'}}</td><td><button @click="toggle(account)">{{account.is_active?'Suspend':'Restore'}}</button> <button @click="reset(account.id)">Send password reset</button> <button @click="remove(account.id)">Remove</button></td></tr></tbody></table></section></main></template>
-<script setup lang="ts">import{onMounted,ref}from"vue";import{RouterLink}from"vue-router";import{createTenantAccount,listTenantAccounts,removeTenantAccount,sendTenantAccountReset,setTenantAccountStatus,type TenantAccount}from"../../../services/workspaceAdminManageService";const accounts=ref<TenantAccount[]>([]),email=ref(""),message=ref(""),busy=ref(false);const load=async()=>accounts.value=await listTenantAccounts();const create=async()=>{busy.value=true;try{await createTenantAccount(email.value);email.value="";message.value="Tenant Account created and setup email requested.";await load();}finally{busy.value=false;}};const toggle=async(a:TenantAccount)=>{await setTenantAccountStatus(a.id,!a.is_active);await load();};const reset=async(id:string)=>{await sendTenantAccountReset(id);message.value="Password reset requested.";};const remove=async(id:string)=>{if(confirm("Remove this Tenant Account? Existing records are retained.")){await removeTenantAccount(id);await load();}};onMounted(()=>void load());</script>
+<template>
+  <main class="page admin-shell">
+    <RouterLink to="/admin">Return to admin panel</RouterLink>
+    <h1>Tenant Accounts</h1>
+    <section class="card">
+      <h2>Add Tenant Account</h2>
+      <form class="add-account-form" @submit.prevent="create">
+        <input v-model="email" type="email" autocomplete="email" placeholder="Email address" required />
+        <button :disabled="busy">Create and send setup link</button>
+      </form>
+      <p v-if="message">{{ message }}</p>
+    </section>
+    <section class="card">
+      <h2>Accounts</h2>
+      <div class="table-wrap">
+        <table class="table accounts-table">
+          <thead>
+            <tr>
+              <th>Email</th>
+              <th>Status</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="account in accounts" :key="account.id">
+              <td>{{ account.auth_email }}</td>
+              <td>{{ account.is_active ? "Active" : "Suspended" }}</td>
+              <td class="accounts-actions">
+                <button type="button" @click="toggle(account)">
+                  {{ account.is_active ? "Suspend" : "Restore" }}
+                </button>
+                <button type="button" @click="reset(account.id)">Send password reset</button>
+                <button type="button" @click="remove(account.id)">Remove</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { RouterLink } from "vue-router";
+import {
+  createTenantAccount,
+  listTenantAccounts,
+  removeTenantAccount,
+  sendTenantAccountReset,
+  setTenantAccountStatus,
+  type TenantAccount,
+} from "../../../services/workspaceAdminManageService";
+
+const accounts = ref<TenantAccount[]>([]);
+const email = ref("");
+const message = ref("");
+const busy = ref(false);
+
+const load = async () => {
+  accounts.value = await listTenantAccounts();
+};
+
+const create = async () => {
+  busy.value = true;
+  try {
+    await createTenantAccount(email.value);
+    email.value = "";
+    message.value = "Tenant Account created and setup email requested.";
+    await load();
+  } finally {
+    busy.value = false;
+  }
+};
+
+const toggle = async (account: TenantAccount) => {
+  await setTenantAccountStatus(account.id, !account.is_active);
+  await load();
+};
+
+const reset = async (id: string) => {
+  await sendTenantAccountReset(id);
+  message.value = "Password reset requested.";
+};
+
+const remove = async (id: string) => {
+  if (confirm("Remove this Tenant Account? Existing records are retained.")) {
+    await removeTenantAccount(id);
+    await load();
+  }
+};
+
+onMounted(() => void load());
+</script>
+
+<style scoped>
+.add-account-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  align-items: flex-start;
+}
+
+.accounts-table th:nth-child(1),
+.accounts-table td:nth-child(1) {
+  width: 45%;
+}
+
+.accounts-table th:nth-child(2),
+.accounts-table td:nth-child(2) {
+  width: 15%;
+}
+
+.accounts-table th:nth-child(3),
+.accounts-table td:nth-child(3) {
+  width: 40%;
+}
+
+.accounts-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+</style>

--- a/src/pages/workspace/admin/AdminHome.vue
+++ b/src/pages/workspace/admin/AdminHome.vue
@@ -4,20 +4,10 @@
         <div class="admin-toolbar">
             <div class="muted">Signed in as {{ adminEmail }}</div>
         </div>
-      <h1>Admin Panel</h1>
+      <h1>Workspace Overview</h1>
         <p class="admin-hero-copy">
           Manage inventory, borrowers, returns, reporting, and account controls from one workspace.
         </p>
-        <div class="admin-summary-grid">
-          <div class="admin-summary-card">
-            <strong>{{ accountCategoryLabel }}</strong>
-            <span>Account category</span>
-          </div>
-          <div class="admin-summary-card">
-            <strong>{{ planLabel }}</strong>
-            <span>Plan</span>
-          </div>
-        </div>
       </div>
 
     <div class="admin-grid">
@@ -66,7 +56,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref } from "vue";
+import { computed, onMounted, reactive } from "vue";
 import { RouterLink } from "vue-router";
 import { getAuthState } from "../../../store/authState";
 import { fetchWorkspaceSettings } from "../../../services/adminOpsService";
@@ -82,61 +72,10 @@ const featureFlags = reactive({
   enable_status_tracking: true,
   enable_barcode_generator: true,
 });
-const accountCategory = ref<"organization" | "district" | "individual" | null>(null);
-const planCode = ref<
-  | "core"
-  | "growth"
-  | "starter"
-  | "scale"
-  | "enterprise"
-  | "individual_yearly"
-  | "individual_monthly"
-  | null
->(null);
-
-const accountCategoryLabel = computed(() =>
-  accountCategory.value === "individual"
-    ? "Individual"
-    : accountCategory.value === "district"
-      ? "District"
-    : accountCategory.value === "organization"
-      ? "Organization"
-      : "Unavailable"
-);
-const planLabel = computed(() => {
-  switch (planCode.value) {
-    case "core":
-      return "Core";
-    case "growth":
-      return "Growth";
-    case "starter":
-      return "Starter";
-    case "scale":
-      return "Scale";
-    case "enterprise":
-      return "Enterprise";
-    case "individual_yearly":
-      return "Individual Yearly";
-    case "individual_monthly":
-      return "Individual Monthly";
-    default:
-      return "Unavailable";
-  }
-});
-
 onMounted(async () => {
   try {
     const settings = await fetchWorkspaceSettings();
     Object.assign(featureFlags, settings.feature_flags);
-    accountCategory.value =
-      settings.account_category === "individual"
-        ? "individual"
-        : settings.account_category === "district"
-          ? "district"
-        : settings.account_category === "organization"
-          ? "organization"
-          : null;
-    planCode.value = settings.plan_code ?? null;
   } catch {
     // Keep defaults if tenant settings cannot be loaded.
   }

--- a/src/pages/workspace/admin/Admins.vue
+++ b/src/pages/workspace/admin/Admins.vue
@@ -157,9 +157,18 @@
           ×
         </button>
         <h3>Primary Admin Email</h3>
-        <p class="primary-admin-email-value">{{ primaryAdminEmailValue }}</p>
-        <div class="form-actions">
-          <button type="button" class="button-primary" @click="copyPrimaryAdminEmail">Copy email</button>
+        <div class="primary-admin-email-row">
+          <button
+            type="button"
+            class="primary-admin-copy-button"
+            :class="{ copied: primaryAdminEmailCopied }"
+            :aria-label="primaryAdminEmailCopied ? 'Email copied' : 'Copy email'"
+            @click="copyPrimaryAdminEmail"
+          >
+            <span v-if="primaryAdminEmailCopied" aria-hidden="true">✓</span>
+            <span v-else aria-hidden="true">⧉</span>
+          </button>
+          <span class="primary-admin-email-value">{{ primaryAdminEmailValue }}</span>
         </div>
       </div>
     </div>
@@ -279,13 +288,26 @@ const openPrimaryAdminModal = () => {
 
 const closePrimaryAdminModal = () => {
   primaryAdminModalVisible.value = false;
+  primaryAdminEmailCopied.value = false;
+  if (primaryAdminCopyTimer) {
+    window.clearTimeout(primaryAdminCopyTimer);
+    primaryAdminCopyTimer = null;
+  }
 };
+
+const primaryAdminEmailCopied = ref(false);
+let primaryAdminCopyTimer: number | null = null;
 
 const copyPrimaryAdminEmail = async () => {
   if (!primaryAdminEmailValue.value) return;
   try {
     await navigator.clipboard.writeText(primaryAdminEmailValue.value);
-    showToast("Copied", "Email copied.");
+    primaryAdminEmailCopied.value = true;
+    if (primaryAdminCopyTimer) window.clearTimeout(primaryAdminCopyTimer);
+    primaryAdminCopyTimer = window.setTimeout(() => {
+      primaryAdminEmailCopied.value = false;
+      primaryAdminCopyTimer = null;
+    }, 1500);
   } catch {
     showToast("Copy failed", "Unable to copy email. Please copy manually.");
   }
@@ -349,6 +371,10 @@ onUnmounted(() => {
   if (toastTimer) {
     window.clearTimeout(toastTimer);
     toastTimer = null;
+  }
+  if (primaryAdminCopyTimer) {
+    window.clearTimeout(primaryAdminCopyTimer);
+    primaryAdminCopyTimer = null;
   }
 });
 </script>
@@ -431,11 +457,36 @@ onUnmounted(() => {
   justify-content: center;
 }
 
-.primary-admin-email-value {
+.primary-admin-email-row {
   margin: 0.75rem 0 1rem;
   padding: 0.75rem 0.9rem;
   border: 1px solid var(--border);
   background: var(--surface-2);
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.primary-admin-copy-button {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  transition: background-color 160ms ease, border-color 160ms ease;
+}
+
+.primary-admin-copy-button.copied {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.primary-admin-email-value {
   white-space: nowrap;
   overflow-x: auto;
   font-weight: 700;

--- a/src/pages/workspace/admin/Borrowers.vue
+++ b/src/pages/workspace/admin/Borrowers.vue
@@ -15,10 +15,6 @@
           <strong>{{ archivedBorrowers.length }}</strong>
           <span>Archived borrowers</span>
         </div>
-        <div class="admin-summary-card">
-          <strong>{{ filteredBorrowers.length }}</strong>
-          <span>Visible in table</span>
-        </div>
       </div>
     </div>
 
@@ -48,12 +44,11 @@
             title="If you need to change this, contact support."
           />
         </label>
-        <fieldset>
-          <legend>Tenant Account access</legend>
-          <label><input v-model="accessMode" type="radio" value="all" /> All Tenant Accounts</label>
-          <label><input v-model="accessMode" type="radio" value="restricted" /> Specific Tenant Accounts</label>
-          <div v-if="accessMode === 'restricted'"><label v-for="account in tenantAccounts" :key="account.id"><input v-model="selectedProfileIds" type="checkbox" :value="account.id" /> {{ account.auth_email }}</label></div>
-        </fieldset>
+        <TenantAccessPicker
+          v-model:access-mode="accessMode"
+          v-model:selected-ids="selectedProfileIds"
+          :accounts="tenantAccounts"
+        />
         <div class="form-actions">
           <button type="button" @click="regenerateIdentity">Regenerate</button>
           <button type="submit" class="button-primary" :disabled="isSaving">Add borrower</button>
@@ -82,7 +77,16 @@
         <div class="admin-toolbar-actions">
           <button type="button" @click="exportCsv">Export CSV</button>
           <button type="button" @click="exportPdf">Export PDF</button>
+          <button type="button" @click="toggleBulkMode">
+            {{ bulkMode ? "Exit bulk actions" : "Bulk actions" }}
+          </button>
         </div>
+      </div>
+
+      <div v-if="bulkMode && selectedBorrowerIds.size > 0" class="bulk-action-bar">
+        <span>{{ selectedBorrowerIds.size }} selected</span>
+        <button type="button" @click="openBulkAccessModal">Change tenant account access</button>
+        <button type="button" :disabled="isSaving" @click="applyBulkArchive">Archive selected</button>
       </div>
       <div class="form-grid-2">
         <label>
@@ -100,13 +104,29 @@
       <table class="table">
         <thead>
           <tr>
+            <th v-if="bulkMode">
+              <input
+                type="checkbox"
+                :checked="allFilteredSelected"
+                @change="toggleSelectAll"
+                aria-label="Select all borrowers"
+              />
+            </th>
             <th>Username</th>
             <th>Borrower ID</th>
             <th>Details</th>
           </tr>
         </thead>
         <tbody>
-          <tr v-for="item in filteredBorrowers" :key="item.id">
+          <tr v-for="(item, index) in filteredBorrowers" :key="item.id">
+            <td v-if="bulkMode">
+              <input
+                type="checkbox"
+                :checked="selectedBorrowerIds.has(item.id)"
+                @click="toggleBorrowerSelection(item.id, index, $event)"
+                :aria-label="`Select ${item.username}`"
+              />
+            </td>
             <td>{{ item.username }}</td>
             <td>{{ item.borrower_id }}</td>
             <td>
@@ -188,34 +208,30 @@
       </p>
     </div>
 
+    <div v-if="showBulkAccessModal" class="modal-backdrop">
+      <div class="modal">
+        <h2>Change tenant account access</h2>
+        <p class="admin-section-copy">Applies to {{ selectedBorrowerIds.size }} selected borrower(s).</p>
+        <TenantAccessPicker
+          v-model:access-mode="bulkAccessMode"
+          v-model:selected-ids="bulkAccessProfileIds"
+          :accounts="tenantAccounts"
+        />
+        <div class="admin-actions">
+          <button type="button" class="link" :disabled="!bulkAccessMode || isSaving" @click="applyBulkAccess">
+            Apply
+          </button>
+          <button type="button" class="link" @click="showBulkAccessModal = false">Cancel</button>
+        </div>
+      </div>
+    </div>
+
     <div v-if="showDetails" class="modal-backdrop">
       <div class="modal">
         <h2>Borrower details</h2>
         <p class="muted">View username, borrower ID, and checkout history.</p>
         <h3>{{ selected?.username }}</h3>
         <p class="muted">Borrower ID: {{ selected?.borrower_id }}</p>
-        <div class="form-grid-2">
-          <label>
-            Username
-            <input
-              class="identity-readonly"
-              :value="selected?.username || ''"
-              type="text"
-              readonly
-              title="If you need to change this, contact support."
-            />
-          </label>
-          <label>
-            Borrower ID
-            <input
-              class="identity-readonly"
-              :value="selected?.borrower_id || ''"
-              type="text"
-              readonly
-              title="If you need to change this, contact support."
-            />
-          </label>
-        </div>
 
         <SkeletonLoader v-if="detailsLoading" variant="lines" :rows="3" label="Loading borrower details" />
         <div v-else>
@@ -262,6 +278,7 @@
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import { RouterLink } from "vue-router";
 import SkeletonLoader from "../../../components/SkeletonLoader.vue";
+import TenantAccessPicker from "../../../components/app/TenantAccessPicker.vue";
 import { getAuthState } from "../../../store/authState";
 import {
   bulkCreateBorrowers,
@@ -271,6 +288,7 @@ import {
   fetchBorrowerDetails,
   fetchBorrowers,
   restoreBorrower,
+  updateBorrowerAccess,
   type BorrowerDetails,
   type BorrowerItem,
 } from "../../../services/borrowerService";
@@ -311,6 +329,12 @@ const featureFlags = ref({
 });
 const bulkGenerateCount = ref(20);
 const bulkRows = ref<Array<{ username: string; borrower_id: string }>>([]);
+const bulkMode = ref(false);
+const selectedBorrowerIds = ref<Set<string>>(new Set());
+const lastSelectedIndex = ref<number | null>(null);
+const showBulkAccessModal = ref(false);
+const bulkAccessMode = ref<"" | "all" | "restricted">("");
+const bulkAccessProfileIds = ref<string[]>([]);
 let toastTimer: number | null = null;
 
 const matchesSearch = (item: BorrowerItem, query: string) => {
@@ -328,6 +352,85 @@ const filteredArchivedBorrowers = computed(() => {
   const query = searchQuery.value.trim().toLowerCase();
   return archivedBorrowers.value.filter((item) => matchesSearch(item, query));
 });
+
+const allFilteredSelected = computed(
+  () =>
+    filteredBorrowers.value.length > 0 &&
+    filteredBorrowers.value.every((item) => selectedBorrowerIds.value.has(item.id))
+);
+
+const toggleBulkMode = () => {
+  bulkMode.value = !bulkMode.value;
+  selectedBorrowerIds.value = new Set();
+  lastSelectedIndex.value = null;
+};
+
+const toggleSelectAll = () => {
+  selectedBorrowerIds.value = allFilteredSelected.value
+    ? new Set()
+    : new Set(filteredBorrowers.value.map((item) => item.id));
+};
+
+const toggleBorrowerSelection = (id: string, index: number, event: MouseEvent) => {
+  const next = new Set(selectedBorrowerIds.value);
+  if (event.shiftKey && lastSelectedIndex.value !== null) {
+    const [start, end] = [lastSelectedIndex.value, index].sort((a, b) => a - b);
+    for (let i = start; i <= end; i++) {
+      next.add(filteredBorrowers.value[i].id);
+    }
+  } else if (next.has(id)) {
+    next.delete(id);
+  } else {
+    next.add(id);
+  }
+  selectedBorrowerIds.value = next;
+  lastSelectedIndex.value = index;
+};
+
+const openBulkAccessModal = () => {
+  bulkAccessMode.value = "";
+  bulkAccessProfileIds.value = [];
+  showBulkAccessModal.value = true;
+};
+
+const applyBulkAccess = async () => {
+  const accessMode = bulkAccessMode.value;
+  if (accessMode !== "all" && accessMode !== "restricted") return;
+  isSaving.value = true;
+  try {
+    for (const id of selectedBorrowerIds.value) {
+      await updateBorrowerAccess({ id, access_mode: accessMode, profile_ids: bulkAccessProfileIds.value });
+    }
+    success.value = "Tenant account access updated.";
+    showBulkAccessModal.value = false;
+    selectedBorrowerIds.value = new Set();
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : "Unable to update tenant account access.";
+  } finally {
+    isSaving.value = false;
+  }
+};
+
+const applyBulkArchive = async () => {
+  const targets = borrowers.value.filter((row) => selectedBorrowerIds.value.has(row.id));
+  if (targets.length === 0) return;
+  const confirmed = window.confirm(`Archive ${targets.length} selected borrower(s)? You can restore them later.`);
+  if (!confirmed) return;
+  isSaving.value = true;
+  try {
+    for (const item of targets) {
+      await deleteBorrower(item.id);
+      borrowers.value = borrowers.value.filter((row) => row.id !== item.id);
+      archivedBorrowers.value = [item, ...archivedBorrowers.value];
+    }
+    success.value = "Selected borrowers archived.";
+    selectedBorrowerIds.value = new Set();
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : "Unable to archive selected borrowers.";
+  } finally {
+    isSaving.value = false;
+  }
+};
 
 const showToast = (title: string, message: string) => {
   toastTitle.value = title;
@@ -656,9 +759,15 @@ onUnmounted(() => {
   margin-top: 0.75rem;
 }
 
-.identity-readonly {
-  width: auto;
-  min-width: 120px;
-  max-width: 100%;
+.bulk-action-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.85rem;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface-2);
 }
 </style>

--- a/src/pages/workspace/admin/Items.vue
+++ b/src/pages/workspace/admin/Items.vue
@@ -16,10 +16,6 @@
           <strong>{{ archivedItem.length }}</strong>
           <span>Archived items</span>
         </div>
-        <div class="admin-summary-card">
-          <strong>{{ filteredItem.length }}</strong>
-          <span>Visible in table</span>
-        </div>
       </div>
     </div>
 
@@ -63,14 +59,11 @@
             <span>{{ notes.length }}/500</span>
           </div>
         </label>
-        <fieldset>
-          <legend>Tenant Account access</legend>
-          <label><input v-model="accessMode" type="radio" value="all" /> All Tenant Accounts</label>
-          <label><input v-model="accessMode" type="radio" value="restricted" /> Specific Tenant Accounts</label>
-          <div v-if="accessMode === 'restricted'">
-            <label v-for="account in tenantAccounts" :key="account.id"><input v-model="selectedProfileIds" type="checkbox" :value="account.id" /> {{ account.auth_email }}</label>
-          </div>
-        </fieldset>
+        <TenantAccessPicker
+          v-model:access-mode="accessMode"
+          v-model:selected-ids="selectedProfileIds"
+          :accounts="tenantAccounts"
+        />
         <button type="submit" class="button-primary" :disabled="isSaving">Add item</button>
       </form>
       <p v-if="error" class="error">{{ error }}</p>
@@ -95,7 +88,21 @@
         <div class="admin-toolbar-actions">
           <button type="button" @click="exportCsv">Export CSV</button>
           <button type="button" @click="exportPdf">Export PDF</button>
+          <button type="button" @click="toggleBulkMode">
+            {{ bulkMode ? "Exit bulk actions" : "Bulk actions" }}
+          </button>
         </div>
+      </div>
+
+      <div v-if="bulkMode && selectedItemIds.size > 0" class="bulk-action-bar">
+        <span>{{ selectedItemIds.size }} selected</span>
+        <button type="button" @click="openBulkAccessModal">Change tenant account access</button>
+        <select v-model="bulkStatusValue">
+          <option value="">Change status…</option>
+          <option v-for="option in editableStatusOptions" :key="option" :value="option">{{ option }}</option>
+        </select>
+        <button type="button" :disabled="!bulkStatusValue || isSaving" @click="applyBulkStatus">Apply status</button>
+        <button type="button" :disabled="isSaving" @click="applyBulkArchive">Archive selected</button>
       </div>
       <div class="form-grid-2">
         <label>
@@ -122,6 +129,14 @@
       <table class="table">
         <thead>
           <tr>
+            <th v-if="bulkMode">
+              <input
+                type="checkbox"
+                :checked="allFilteredSelected"
+                @change="toggleSelectAll"
+                aria-label="Select all items"
+              />
+            </th>
             <th>Name</th>
             <th>Barcode</th>
             <th>Serial</th>
@@ -132,7 +147,15 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="item in filteredItem" :key="item.id">
+          <tr v-for="(item, index) in filteredItem" :key="item.id">
+            <td v-if="bulkMode">
+              <input
+                type="checkbox"
+                :checked="selectedItemIds.has(item.id)"
+                @click="toggleItemSelection(item.id, index, $event)"
+                :aria-label="`Select ${item.name}`"
+              />
+            </td>
             <td>{{ item.name }}</td>
             <td>{{ item.barcode }}</td>
             <td>
@@ -165,7 +188,7 @@
               type="text"
               placeholder="Name"
             />
-            <input v-else :value="selectedItem.name" type="text" readonly />
+            <input v-else :value="selectedItem.name" type="text" readonly class="field-plain" />
           </label>
           <label>
             Barcode
@@ -175,7 +198,7 @@
               type="text"
               placeholder="Barcode"
             />
-            <input v-else :value="selectedItem.barcode" type="text" readonly />
+            <input v-else :value="selectedItem.barcode" type="text" readonly class="field-plain" />
             <button
               v-if="isModalEditing"
               type="button"
@@ -191,7 +214,9 @@
               :value="selectedItem.serial_number || '-'"
               type="text"
               readonly
-              title="To edit the serial number, contact support with the current serial number, barcode, and requested change."
+              disabled
+              class="field-plain field-disabled"
+              title="Serial numbers can't be edited here. Contact support with the current serial number, barcode, and requested change."
             />
           </label>
           <label>
@@ -204,7 +229,7 @@
                 {{ option }}
               </option>
             </select>
-            <input v-else :value="selectedItem.status" type="text" readonly />
+            <input v-else :value="selectedItem.status" type="text" readonly class="field-plain" />
           </label>
         </div>
 
@@ -221,7 +246,7 @@
           <textarea
             v-else
             :value="selectedItem.notes || '-'"
-            class="item-notes-input"
+            class="item-notes-input field-plain"
             rows="3"
             readonly
           ></textarea>
@@ -230,6 +255,13 @@
             <span>{{ (isModalEditing ? editNotes : selectedItem.notes || '').length }}/500</span>
           </div>
         </label>
+
+        <TenantAccessPicker
+          v-if="isModalEditing"
+          v-model:access-mode="editAccessMode"
+          v-model:selected-ids="editSelectedProfileIds"
+          :accounts="tenantAccounts"
+        />
 
         <div class="admin-actions">
           <button
@@ -252,6 +284,24 @@
             Archive item
           </button>
           <button type="button" class="link" @click="closeDetails">Close</button>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="showBulkAccessModal" class="modal-backdrop">
+      <div class="modal">
+        <h2>Change tenant account access</h2>
+        <p class="admin-section-copy">Applies to {{ selectedItemIds.size }} selected item(s).</p>
+        <TenantAccessPicker
+          v-model:access-mode="bulkAccessMode"
+          v-model:selected-ids="bulkAccessProfileIds"
+          :accounts="tenantAccounts"
+        />
+        <div class="admin-actions">
+          <button type="button" class="link" :disabled="!bulkAccessMode || isSaving" @click="applyBulkAccess">
+            Apply
+          </button>
+          <button type="button" class="link" @click="showBulkAccessModal = false">Cancel</button>
         </div>
       </div>
     </div>
@@ -308,6 +358,7 @@ import { computed, onMounted, onUnmounted, ref } from "vue";
 import { RouterLink } from "vue-router";
 import CameraBarcodeScannerModal from "../../../components/CameraBarcodeScannerModal.vue";
 import SkeletonLoader from "../../../components/SkeletonLoader.vue";
+import TenantAccessPicker from "../../../components/app/TenantAccessPicker.vue";
 import { getAuthState } from "../../../store/authState";
 import { logAdminAction } from "../../../services/auditLogService";
 import {
@@ -364,6 +415,15 @@ const editName = ref("");
 const editBarcode = ref("");
 const editStatus = ref(statusOptions[0] ?? "available");
 const editNotes = ref("");
+const editAccessMode = ref<"" | "all" | "restricted">("all");
+const editSelectedProfileIds = ref<string[]>([]);
+const bulkMode = ref(false);
+const selectedItemIds = ref<Set<string>>(new Set());
+const lastSelectedIndex = ref<number | null>(null);
+const bulkStatusValue = ref("");
+const showBulkAccessModal = ref(false);
+const bulkAccessMode = ref<"" | "all" | "restricted">("");
+const bulkAccessProfileIds = ref<string[]>([]);
 const scannerOpen = ref(false);
 const scannerMode = ref<ScannerMode>("admin_item_create");
 let toastTimer: number | null = null;
@@ -394,6 +454,118 @@ const filteredItem = computed(() => {
     return haystack.includes(query);
   });
 });
+
+const allFilteredSelected = computed(
+  () => filteredItem.value.length > 0 && filteredItem.value.every((item) => selectedItemIds.value.has(item.id))
+);
+
+const toggleBulkMode = () => {
+  bulkMode.value = !bulkMode.value;
+  selectedItemIds.value = new Set();
+  lastSelectedIndex.value = null;
+};
+
+const toggleSelectAll = () => {
+  selectedItemIds.value = allFilteredSelected.value
+    ? new Set()
+    : new Set(filteredItem.value.map((item) => item.id));
+};
+
+const toggleItemSelection = (id: string, index: number, event: MouseEvent) => {
+  const next = new Set(selectedItemIds.value);
+  if (event.shiftKey && lastSelectedIndex.value !== null) {
+    const [start, end] = [lastSelectedIndex.value, index].sort((a, b) => a - b);
+    for (let i = start; i <= end; i++) {
+      next.add(filteredItem.value[i].id);
+    }
+  } else if (next.has(id)) {
+    next.delete(id);
+  } else {
+    next.add(id);
+  }
+  selectedItemIds.value = next;
+  lastSelectedIndex.value = index;
+};
+
+const openBulkAccessModal = () => {
+  bulkAccessMode.value = "";
+  bulkAccessProfileIds.value = [];
+  showBulkAccessModal.value = true;
+};
+
+const applyBulkAccess = async () => {
+  const accessMode = bulkAccessMode.value;
+  if (accessMode !== "all" && accessMode !== "restricted") return;
+  isSaving.value = true;
+  try {
+    for (const item of items.value.filter((row) => selectedItemIds.value.has(row.id))) {
+      const updated = await updateItem({
+        id: item.id,
+        name: item.name,
+        barcode: item.barcode,
+        status: item.status,
+        notes: item.notes ?? "",
+        access_mode: accessMode,
+        profile_ids: bulkAccessProfileIds.value,
+      });
+      items.value = items.value.map((row) => (row.id === updated.id ? updated : row));
+    }
+    success.value = "Tenant account access updated.";
+    showBulkAccessModal.value = false;
+    selectedItemIds.value = new Set();
+  } catch (err) {
+    error.value = toUserFacingErrorMessage(err, "Unable to update tenant account access.");
+  } finally {
+    isSaving.value = false;
+  }
+};
+
+const applyBulkStatus = async () => {
+  if (!bulkStatusValue.value) return;
+  isSaving.value = true;
+  try {
+    for (const item of items.value.filter((row) => selectedItemIds.value.has(row.id))) {
+      const updated = await updateItem({
+        id: item.id,
+        name: item.name,
+        barcode: item.barcode,
+        status: bulkStatusValue.value,
+        notes: item.notes ?? "",
+        access_mode: item.access_mode ?? "all",
+        profile_ids: [],
+      });
+      items.value = items.value.map((row) => (row.id === updated.id ? updated : row));
+    }
+    success.value = "Status updated.";
+    bulkStatusValue.value = "";
+    selectedItemIds.value = new Set();
+  } catch (err) {
+    error.value = toUserFacingErrorMessage(err, "Unable to update status.");
+  } finally {
+    isSaving.value = false;
+  }
+};
+
+const applyBulkArchive = async () => {
+  const targets = items.value.filter((row) => selectedItemIds.value.has(row.id));
+  if (targets.length === 0) return;
+  const confirmed = window.confirm(`Archive ${targets.length} selected item(s)? You can restore them later.`);
+  if (!confirmed) return;
+  isSaving.value = true;
+  try {
+    for (const item of targets) {
+      await deleteItem(item.id);
+      items.value = items.value.filter((row) => row.id !== item.id);
+      archivedItem.value = [item, ...archivedItem.value];
+    }
+    success.value = "Selected items archived.";
+    selectedItemIds.value = new Set();
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : "Unable to archive selected items.";
+  } finally {
+    isSaving.value = false;
+  }
+};
 
 const showToast = (title: string, message: string) => {
   toastTitle.value = title;
@@ -600,12 +772,21 @@ const handleCreate = async () => {
   }
 };
 
-const startEdit = (item: ItemRecord) => {
+const startEdit = async (item: ItemRecord) => {
   isModalEditing.value = true;
   editName.value = item.name;
   editBarcode.value = item.barcode;
   editStatus.value = item.status;
   editNotes.value = item.notes ?? "";
+  editAccessMode.value = item.access_mode ?? "all";
+  editSelectedProfileIds.value = [];
+  if (editAccessMode.value === "restricted") {
+    const grants = await authenticatedSelect<Array<{ profile_id: string }>>("item_access_grants", {
+      select: "profile_id",
+      item_id: `eq.${item.id}`,
+    });
+    editSelectedProfileIds.value = grants.map((grant) => grant.profile_id);
+  }
 };
 
 const cancelEdit = () => {
@@ -639,6 +820,11 @@ const saveEdit = async (id: string) => {
     error.value = "Name and barcode fields cannot be blank.";
     return;
   }
+  const accessMode = editAccessMode.value;
+  if (!accessMode || (accessMode === "restricted" && editSelectedProfileIds.value.length === 0)) {
+    error.value = "Choose All Tenant Accounts or select at least one specific account.";
+    return;
+  }
   isSaving.value = true;
   try {
     const previousStatus = selectedItem.value?.status ?? "";
@@ -648,6 +834,8 @@ const saveEdit = async (id: string) => {
       barcode: editBarcode.value.trim(),
       status: editStatus.value,
       notes: editNotes.value.trim(),
+      access_mode: accessMode,
+      profile_ids: editSelectedProfileIds.value,
     });
     await logAdminAction({
       action_type: "item_update",
@@ -671,6 +859,8 @@ const saveEdit = async (id: string) => {
             barcode: updated.barcode,
             status: previousStatus,
             notes: updated.notes ?? "",
+            access_mode: editAccessMode.value || "all",
+            profile_ids: editSelectedProfileIds.value,
           });
           items.value = items.value.map((item) =>
             item.id === reverted.id ? reverted : item
@@ -837,6 +1027,29 @@ onUnmounted(() => {
 
 .item-camera-button {
   margin-top: 0.7rem;
+}
+
+.field-plain {
+  border-color: transparent;
+  background: transparent;
+  padding-left: 0;
+}
+
+.field-disabled {
+  color: var(--muted);
+  opacity: 0.65;
+}
+
+.bulk-action-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.85rem;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface-2);
 }
 
 @media (max-width: 760px) {

--- a/src/pages/workspace/admin/QuickReturn.vue
+++ b/src/pages/workspace/admin/QuickReturn.vue
@@ -6,12 +6,6 @@
       </div>
       <h1>Quick Return</h1>
       <p class="admin-hero-copy">Return items by barcode without needing a borrower ID.</p>
-      <div class="admin-summary-grid">
-        <div class="admin-summary-card">
-          <strong>{{ barcodes.length }}</strong>
-          <span>Queued items</span>
-        </div>
-      </div>
     </div>
 
     <div class="card admin-section-card">

--- a/src/pages/workspace/admin/Settings.vue
+++ b/src/pages/workspace/admin/Settings.vue
@@ -12,14 +12,6 @@
           <span>Due window (hours)</span>
         </div>
         <div class="admin-summary-card">
-          <strong>{{ accountCategoryLabel }}</strong>
-          <span>Account category</span>
-        </div>
-        <div class="admin-summary-card">
-          <strong>{{ planLabel }}</strong>
-          <span>Plan</span>
-        </div>
-        <div class="admin-summary-card">
           <strong>{{ sessions.length }}</strong>
           <span>Active devices</span>
         </div>
@@ -44,7 +36,7 @@
           <span>Assigned plan</span>
         </div>
       </div>
-      <p class="muted">
+      <p class="muted account-overview-copy">
         {{
           accountCategory === "individual"
             ? "This account uses the root ItemTraxx url and is not attached to a custom subdomain."
@@ -375,4 +367,9 @@ onUnmounted(() => {
 });
 </script>
 
-<style scoped></style>
+<style scoped>
+.account-overview-copy {
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+</style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -240,6 +240,7 @@ const routes: RouteRecordRaw[] = [
   { path: "/items", name: "workspace-items", component: () => import("../pages/workspace/Items.vue"), meta: { requiresSession: true, requiresWorkspace: true, requiresRole: "tenant_account", title: "Items | ItemTraxx" } },
   { path: "/borrowers", name: "workspace-borrowers", component: () => import("../pages/workspace/Borrowers.vue"), meta: { requiresSession: true, requiresWorkspace: true, requiresRole: "tenant_account", title: "Borrowers | ItemTraxx" } },
   { path: "/settings", name: "workspace-settings", component: () => import("../pages/workspace/Settings.vue"), meta: { requiresSession: true, requiresWorkspace: true, requiresRole: "tenant_account", title: "Settings | ItemTraxx" } },
+  { path: "/account", name: "workspace-account", component: () => import("../pages/workspace/Account.vue"), meta: { requiresSession: true, requiresWorkspace: true, requiresRole: "tenant_account", title: "My Account | ItemTraxx" } },
   {
     path: "/admin/students",
     redirect: "/admin/borrowers",

--- a/src/services/borrowerService.ts
+++ b/src/services/borrowerService.ts
@@ -97,6 +97,33 @@ export const createBorrower = async (payload: {
   return result.data?.data as BorrowerItem;
 };
 
+export const updateBorrowerAccess = async (payload: {
+  id: string;
+  access_mode: "all" | "restricted";
+  profile_ids: string[];
+}) => {
+  const { deviceId } = getOrCreateDeviceSession();
+  const result = await invokeEdgeFunction<{ success: boolean }>(
+    "admin-borrower-mutate",
+    {
+      method: "POST",
+      body: {
+        action: "update_access",
+        payload: {
+          device_id: deviceId,
+          id: payload.id,
+          access_mode: payload.access_mode,
+          profile_ids: payload.profile_ids,
+        },
+      },
+    }
+  );
+
+  if (!result.ok) {
+    throw edgeFunctionError(result, "Unable to update tenant account access.");
+  }
+};
+
 export const bulkCreateBorrowers = async (
   rows: Array<{ username?: string; borrower_id?: string }>
 ) => {

--- a/src/services/itemService.ts
+++ b/src/services/itemService.ts
@@ -47,7 +47,7 @@ const getWorkspaceContextId = () => {
 export const fetchItem = async () => {
   const workspaceId = getWorkspaceContextId();
   return (await authenticatedSelect<ItemRecord[]>("items", {
-    select: "id,workspace_id,name,barcode,serial_number,status,notes",
+    select: "id,workspace_id,name,barcode,serial_number,status,notes,access_mode",
     workspace_id: `eq.${workspaceId}`,
     deleted_at: "is.null",
     order: "created_at.desc",
@@ -112,6 +112,8 @@ export const updateItem = async (payload: {
   barcode: string;
   status: string;
   notes?: string;
+  access_mode: "all" | "restricted";
+  profile_ids: string[];
 }) => {
   const { deviceId } = getOrCreateDeviceSession();
   const result = await invokeEdgeFunction<{ data: ItemRecord }>("admin-item-mutate", {
@@ -125,6 +127,8 @@ export const updateItem = async (payload: {
         barcode: payload.barcode,
         status: payload.status,
         notes: payload.notes ?? null,
+        access_mode: payload.access_mode,
+        profile_ids: payload.profile_ids,
       },
     },
   });

--- a/src/styles/app-shell.css
+++ b/src/styles/app-shell.css
@@ -989,6 +989,11 @@ body.auth-route-active #app {
   animation: toast-in 0.45s ease-out forwards;
 }
 
+.toast.toast-bottom-left {
+  right: auto;
+  left: 24px;
+}
+
 :root[data-theme="light"] .toast {
   background: #ffffff;
   color: #171717;

--- a/supabase/functions/admin-borrower-mutate/index.ts
+++ b/supabase/functions/admin-borrower-mutate/index.ts
@@ -498,6 +498,7 @@ serve(async (req) => {
     const isMutationAction =
       action === "create" ||
       action === "bulk_create" ||
+      action === "update_access" ||
       action === "delete" ||
       action === "restore";
 
@@ -901,6 +902,54 @@ serve(async (req) => {
       }
 
       return jsonResponse(200, { data });
+    }
+
+    if (action === "update_access") {
+      const { accessMode, profileIds } = await resolveAccess();
+      const { id } = payloadRecord;
+      const normalizedId = requireUuid(id);
+
+      const { data: activeBorrower } = await adminClient
+        .from("borrowers")
+        .select("id")
+        .eq("id", normalizedId)
+        .eq("workspace_id", profile.workspace_id)
+        .is("deleted_at", null)
+        .maybeSingle();
+
+      if (!activeBorrower?.id) {
+        return jsonResponse(404, { error: "Borrower not found." });
+      }
+
+      const { error: updateError } = await adminClient
+        .from("borrowers")
+        .update({ access_mode: accessMode })
+        .eq("id", normalizedId)
+        .eq("workspace_id", profile.workspace_id)
+        .is("deleted_at", null);
+
+      if (updateError) {
+        return jsonResponse(400, { error: "Unable to update tenant account access." });
+      }
+
+      const { error: deleteGrantsError } = await adminClient
+        .from("borrower_access_grants")
+        .delete()
+        .eq("borrower_id", normalizedId);
+      if (deleteGrantsError) {
+        return jsonResponse(400, { error: "Unable to update tenant account access." });
+      }
+
+      if (accessMode === "restricted" && profileIds.length) {
+        const { error: insertGrantsError } = await adminClient
+          .from("borrower_access_grants")
+          .insert(profileIds.map((profileId) => ({ borrower_id: normalizedId, profile_id: profileId, granted_by: user.id })));
+        if (insertGrantsError) {
+          return jsonResponse(400, { error: "Unable to update tenant account access." });
+        }
+      }
+
+      return jsonResponse(200, { success: true });
     }
 
     return jsonResponse(400, { error: "Invalid action" });

--- a/tests/e2e/css-ownership.spec.ts
+++ b/tests/e2e/css-ownership.spec.ts
@@ -38,7 +38,7 @@ test.describe("global CSS ownership contracts", () => {
 
     await setWorkspaceAdminSession(page);
     await navigateApp(page, "/admin");
-    await expect(page.getByRole("heading", { name: "Admin Panel", exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Workspace Overview", exact: true })).toBeVisible();
     await expect.poll(() => authenticatedCssRequests.length).toBe(1);
     expect(
       await page.locator(".admin-grid").evaluate((element) => getComputedStyle(element).display),

--- a/tests/e2e/protected-routes.spec.ts
+++ b/tests/e2e/protected-routes.spec.ts
@@ -22,14 +22,14 @@ test.describe("Protected route smoke tests", () => {
     await setWorkspaceAdminSession(page);
 
     await navigateApp(page, "/admin");
-    await expect(page.getByRole("heading", { name: "Admin Panel", exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Workspace Overview", exact: true })).toBeVisible();
     await expect(page.getByRole("link", { name: "Item Status Tracking" })).toBeVisible();
 
     await navigateApp(page, "/admin/item-status");
     await expect(page.getByRole("heading", { name: "Item Status Tracking" })).toBeVisible();
   });
 
-  test("offline queue badge follows real queue storage transitions", async ({ page }) => {
+  test("offline queue toast follows real queue storage transitions", async ({ page }) => {
     await page.goto("/");
     await page.evaluate(() => {
       localStorage.setItem("itemtraxx:onboarding:v1:workspace_admin", new Date().toISOString());
@@ -37,13 +37,8 @@ test.describe("Protected route smoke tests", () => {
     await setWorkspaceAdminSession(page);
     await navigateApp(page, "/checkout");
 
-    await page.getByRole("button", { name: "Open menu" }).click();
-    await expect(page.getByRole("menuitem", { name: "Open Admin Panel" })).toBeVisible();
-    await expect(page.getByRole("menuitem", { name: "Take tour again" })).toBeVisible();
-    await expect(page.getByRole("menuitem", { name: "Offline Queue: 0" })).toHaveAttribute(
-      "title",
-      /auto-syncs them when connection is restored/,
-    );
+    const toast = page.locator(".toast-bottom-left");
+    await expect(toast).toHaveCount(0);
 
     await page.evaluate(async () => {
       await window.__itemtraxxTest?.offlineCheckoutQueue.queue({
@@ -56,10 +51,8 @@ test.describe("Protected route smoke tests", () => {
         new StorageEvent("storage", { key: "itemtraxx:checkout-offline-buffer:v1" }),
       );
     });
-    if (!(await page.getByRole("menuitem", { name: "Offline Queue: 1" }).isVisible())) {
-      await page.getByRole("button", { name: "Open menu" }).click();
-    }
-    await expect(page.getByRole("menuitem", { name: "Offline Queue: 1" })).toBeVisible();
+    await expect(toast).toBeVisible();
+    await expect(toast).toContainText("1 checkout waiting to sync.");
 
     await page.evaluate(async () => {
       await window.__itemtraxxTest?.offlineCheckoutQueue.write([]);
@@ -67,13 +60,10 @@ test.describe("Protected route smoke tests", () => {
         new StorageEvent("storage", { key: "itemtraxx:checkout-offline-buffer:v1" }),
       );
     });
-    if (!(await page.getByRole("menuitem", { name: "Offline Queue: 0" }).isVisible())) {
-      await page.getByRole("button", { name: "Open menu" }).click();
-    }
-    await expect(page.getByRole("menuitem", { name: "Offline Queue: 0" })).toBeVisible();
+    await expect(toast).toHaveCount(0);
   });
 
-  test("onboarding completion survives reload and replay reopens the tour", async ({ page }) => {
+  test("onboarding completion survives reload", async ({ page }) => {
     await page.goto("/");
     await page.evaluate(() => {
       localStorage.removeItem("itemtraxx:onboarding:v1:workspace_admin");
@@ -96,9 +86,6 @@ test.describe("Protected route smoke tests", () => {
     );
     await page.evaluate(() => window.__itemtraxxTest?.setWorkspaceAdminSession("tenant-e2e"));
     await expect(dialog).toHaveCount(0);
-    await page.getByRole("button", { name: "Open menu" }).click();
-    await page.getByRole("menuitem", { name: "Take tour again" }).click();
-    await expect(dialog).toBeVisible();
   });
 
   test("authenticated users can dismiss a degraded incident without changing its status link", async ({ page }) => {
@@ -208,7 +195,7 @@ test.describe("Protected route smoke tests", () => {
     await navigateApp(page, "/admin");
 
     await expect(page).toHaveURL(/\/admin$/);
-    await expect(page.getByRole("heading", { name: "Admin Panel", exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Workspace Overview", exact: true })).toBeVisible();
   });
 
   test("super-admin secondary verification expires after 15 minutes", async ({ page }) => {

--- a/tests/e2e/super-flows-and-exports.spec.ts
+++ b/tests/e2e/super-flows-and-exports.spec.ts
@@ -91,18 +91,13 @@ test.describe("Super admin flows and export actions", () => {
     await expect(page.getByRole("button", { name: "Export PDF" })).toBeVisible();
   });
 
-  test("super-admin top navigation preserves role actions and system status", async ({ page }) => {
+  test("super-admin top navigation preserves role actions", async ({ page }) => {
     await page.goto("/");
     await setSuperAdminSession(page);
     await navigateApp(page, "/super-admin");
 
     await page.getByRole("button", { name: "Open menu" }).click();
-    await expect(page.getByRole("menuitem", { name: "Open Admin Panel" })).toBeVisible();
     await expect(page.getByRole("menuitem", { name: "Log Out User" })).toBeVisible();
-    await expect(page.getByRole("menuitem", { name: /System Status: Running/ })).toHaveAttribute(
-      "href",
-      "https://status.itemtraxx.com/?ref=trmenu",
-    );
   });
 
   test("control-center actions preserve their exact request envelopes", async ({ page }) => {

--- a/tests/e2e/workspace-model.spec.ts
+++ b/tests/e2e/workspace-model.spec.ts
@@ -84,10 +84,10 @@ test.describe("workspace model role surfaces", () => {
     await setWorkspaceAdminSession(page);
     await navigateApp(page, "/admin/items");
 
-    const all = page.getByRole("radio", { name: "All Tenant Accounts" });
-    const restricted = page.getByRole("radio", { name: "Specific Tenant Accounts" });
-    await expect(all).not.toBeChecked();
-    await expect(restricted).not.toBeChecked();
+    const all = page.getByRole("button", { name: "All Tenant Accounts" });
+    const restricted = page.getByRole("button", { name: "Specific Tenant Accounts" });
+    await expect(all).toHaveAttribute("aria-pressed", "false");
+    await expect(restricted).toHaveAttribute("aria-pressed", "false");
     await page.getByPlaceholder("Item name").fill("Explicit choice item");
     await page.getByPlaceholder("Barcode", { exact: true }).fill("EXPLICIT-1");
     await page.getByRole("button", { name: "Add item" }).click();


### PR DESCRIPTION
## Summary
- Strip top-right menu to theme toggle / My Account (tenant-only) / Log Out; offline queue moved to a bottom-left toast.
- New self-service My Account page for regular tenants: paginated read-only borrowers + items, device session revoke. No secondary auth.
- Admin pages: reusable chip-style tenant-access picker, bulk actions on Items/Borrowers, edit-mode field outlines + locked serial number on Items, deduped borrower detail fields, redone Accounts table, copy-with-feedback primary admin email modal.
- Backend: new `update_access` action on `admin-borrower-mutate` (mirrors `admin-item-mutate`'s existing pattern, preserves `granted_by` audit trail per #751/#752). Frontend now sends `access_mode`/`profile_ids` on item update (backend already accepted them).

## Test plan
- [x] `vue-tsc -b` clean
- [x] `npm run build` clean
- [x] Public footer verified in browser (Admin Login link gone, no console errors)
- [ ] Manual click-through of authenticated pages (Items/Borrowers/Admins/Account panel) on staging — not verifiable locally without live backend/credentials