### PR TITLE
fix(account): use real table markup and match admin session UI

### DIFF
--- a/src/pages/workspace/Account.vue
+++ b/src/pages/workspace/Account.vue
@@ -10,25 +10,35 @@
       </nav>
     </header>
 
-    <section>
-      <h2>Borrowers</h2>
+    <section class="card admin-section-card">
+      <div class="admin-section-header">
+        <div>
+          <h2>Borrowers</h2>
+          <p class="admin-section-copy">Read-only view of this workspace's borrowers.</p>
+        </div>
+      </div>
       <p v-if="borrowersLoading">Loading…</p>
       <p v-else-if="borrowersError" class="error">{{ borrowersError }}</p>
       <template v-else>
-        <table>
-          <thead>
-            <tr>
-              <th>Username</th>
-              <th>Borrower ID</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="borrower in pagedBorrowers" :key="borrower.id">
-              <td>{{ borrower.username }}</td>
-              <td>{{ borrower.borrower_id }}</td>
-            </tr>
-          </tbody>
-        </table>
+        <div class="table-wrap">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Username</th>
+                <th>Borrower ID</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="borrower in pagedBorrowers" :key="borrower.id">
+                <td>{{ borrower.username }}</td>
+                <td>{{ borrower.borrower_id }}</td>
+              </tr>
+              <tr v-if="!pagedBorrowers.length">
+                <td colspan="2" class="muted">No borrowers found.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
         <div class="account-pagination">
           <button type="button" :disabled="borrowerPage === 0" @click="borrowerPage--">‹ Previous 20</button>
           <span>{{ borrowerPageLabel }}</span>
@@ -37,27 +47,37 @@
       </template>
     </section>
 
-    <section>
-      <h2>Items</h2>
+    <section class="card admin-section-card">
+      <div class="admin-section-header">
+        <div>
+          <h2>Items</h2>
+          <p class="admin-section-copy">Read-only view of this workspace's items.</p>
+        </div>
+      </div>
       <p v-if="itemsLoading">Loading…</p>
       <p v-else-if="itemsError" class="error">{{ itemsError }}</p>
       <template v-else>
-        <table>
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Barcode</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="item in pagedItems" :key="item.id">
-              <td>{{ item.name }}</td>
-              <td>{{ item.barcode }}</td>
-              <td>{{ item.status }}</td>
-            </tr>
-          </tbody>
-        </table>
+        <div class="table-wrap">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Barcode</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="item in pagedItems" :key="item.id">
+                <td>{{ item.name }}</td>
+                <td>{{ item.barcode }}</td>
+                <td>{{ item.status }}</td>
+              </tr>
+              <tr v-if="!pagedItems.length">
+                <td colspan="3" class="muted">No items found.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
         <div class="account-pagination">
           <button type="button" :disabled="itemPage === 0" @click="itemPage--">‹ Previous 20</button>
           <span>{{ itemPageLabel }}</span>
@@ -66,17 +86,75 @@
       </template>
     </section>
 
-    <section>
-      <h2>Signed-in devices</h2>
-      <button type="button" @click="loadSessions">Refresh</button>
-      <ul>
-        <li v-for="session in sessions" :key="session.id">
-          <strong>{{ session.device_label || "Unknown device" }}</strong>
-          — last used {{ new Date(session.last_seen_at).toLocaleString() }}
-          <span v-if="session.is_current">(current)</span>
-          <button type="button" @click="revokeSession(session.id)">Revoke</button>
-        </li>
-      </ul>
+    <section class="card admin-section-card">
+      <div class="admin-section-header">
+        <div>
+          <h2>Active Devices</h2>
+          <p class="admin-section-copy">Review active sessions for your account and remotely sign out devices.</p>
+        </div>
+      </div>
+      <div class="table-wrap">
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Device</th>
+              <th>Login method</th>
+              <th>Login flow</th>
+              <th>Location</th>
+              <th>Last seen</th>
+              <th>Signed in</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="session in sessions" :key="session.id">
+              <td>{{ session.device_label || "Unknown device" }}</td>
+              <td>{{ formatLoginMethod(session.login_method) }}</td>
+              <td>{{ formatLoginLocation(session.login_location) }}</td>
+              <td>{{ formatGeneralLocation(session.general_location) }}</td>
+              <td>{{ formatDate(session.last_seen_at) }}</td>
+              <td>{{ formatDate(session.created_at) }}</td>
+              <td>{{ session.is_current ? "Current" : "Active" }}</td>
+            </tr>
+            <tr v-if="!sessions.length">
+              <td colspan="7" class="muted">No active sessions found.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="form-actions">
+        <label class="session-select">
+          Select device
+          <select v-model="selectedSessionId">
+            <option value="">Choose a device</option>
+            <option
+              v-for="session in removableSessions"
+              :key="session.id"
+              :value="session.id"
+            >
+              {{ session.device_label || "Unknown device" }} — {{ formatDate(session.last_seen_at) }}
+            </option>
+          </select>
+        </label>
+      </div>
+      <div class="form-actions">
+        <button
+          type="button"
+          :disabled="isSessionSaving || !selectedSessionId"
+          @click="handleSignOutSelected"
+        >
+          Sign out selected device
+        </button>
+        <button
+          type="button"
+          :disabled="isSessionSaving || !removableSessions.length"
+          @click="handleSignOutAllOthers"
+        >
+          Sign out all other devices
+        </button>
+      </div>
+      <p v-if="sessionError" class="error">{{ sessionError }}</p>
+      <p v-if="sessionSuccess" class="success">{{ sessionSuccess }}</p>
     </section>
   </main>
 </template>
@@ -85,9 +163,11 @@
 import { computed, onMounted, ref } from "vue";
 import { RouterLink } from "vue-router";
 import { authenticatedSelect } from "../../services/authenticatedDataClient";
+import { toUserFacingErrorMessage } from "../../services/appErrors";
 import {
   listAccountSessions,
   revokeAccountSession,
+  revokeAllAccountSessions,
   type AccountSessionItem,
 } from "../../services/adminOpsService";
 
@@ -107,6 +187,10 @@ const itemsError = ref("");
 const itemPage = ref(0);
 
 const sessions = ref<AccountSessionItem[]>([]);
+const selectedSessionId = ref("");
+const isSessionSaving = ref(false);
+const sessionError = ref("");
+const sessionSuccess = ref("");
 
 const pagedBorrowers = computed(() =>
   borrowers.value.slice(borrowerPage.value * PAGE_SIZE, (borrowerPage.value + 1) * PAGE_SIZE),
@@ -129,6 +213,33 @@ const itemPageLabel = computed(() => {
   const end = Math.min(items.value.length, (itemPage.value + 1) * PAGE_SIZE);
   return `${start}–${end} of ${items.value.length}`;
 });
+
+const removableSessions = computed(() => sessions.value.filter((session) => !session.is_current));
+
+const formatLoginMethod = (value: AccountSessionItem["login_method"]) =>
+  value === "password"
+    ? "Password"
+    : value === "magic_link"
+      ? "Magic link"
+      : value === "session_handoff"
+        ? "Session handoff"
+        : "Unknown";
+
+const formatLoginLocation = (value: AccountSessionItem["login_location"]) =>
+  value === "regular_login"
+    ? "Regular login"
+    : value === "admin_login"
+      ? "Admin sign in"
+      : "Unknown";
+
+const formatGeneralLocation = (value: AccountSessionItem["general_location"]) =>
+  value?.trim() ? value : "Unknown";
+
+const formatDate = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+  return date.toLocaleString();
+};
 
 const loadBorrowers = async () => {
   try {
@@ -159,12 +270,50 @@ const loadItems = async () => {
 };
 
 const loadSessions = async () => {
-  sessions.value = (await listAccountSessions()).sessions;
+  sessionError.value = "";
+  sessionSuccess.value = "";
+  try {
+    const data = await listAccountSessions();
+    sessions.value = data.sessions ?? [];
+    if (selectedSessionId.value && !sessions.value.some((row) => row.id === selectedSessionId.value)) {
+      selectedSessionId.value = "";
+    }
+  } catch (err) {
+    sessionError.value = toUserFacingErrorMessage(err, "Unable to load sessions.");
+  }
 };
 
-const revokeSession = async (id: string) => {
-  await revokeAccountSession(id);
-  await loadSessions();
+const handleSignOutSelected = async () => {
+  if (!selectedSessionId.value) return;
+  isSessionSaving.value = true;
+  sessionError.value = "";
+  sessionSuccess.value = "";
+  try {
+    await revokeAccountSession(selectedSessionId.value);
+    selectedSessionId.value = "";
+    sessionSuccess.value = "Selected device signed out.";
+    await loadSessions();
+  } catch (err) {
+    sessionError.value = toUserFacingErrorMessage(err, "Unable to sign out selected device.");
+  } finally {
+    isSessionSaving.value = false;
+  }
+};
+
+const handleSignOutAllOthers = async () => {
+  isSessionSaving.value = true;
+  sessionError.value = "";
+  sessionSuccess.value = "";
+  try {
+    await revokeAllAccountSessions(false);
+    selectedSessionId.value = "";
+    sessionSuccess.value = "All other devices signed out.";
+    await loadSessions();
+  } catch (err) {
+    sessionError.value = toUserFacingErrorMessage(err, "Unable to sign out all other devices.");
+  } finally {
+    isSessionSaving.value = false;
+  }
 };
 
 onMounted(() => {


### PR DESCRIPTION
Borrowers/items tables now use the .table/.table-wrap classes every other admin table uses, instead of unstyled bare <table> markup. Signed-in devices section is now a 1:1 port of the workspace admin Settings page's Active Devices block (same columns, same sign-out selected/all-others controls) instead of a bespoke list.