### PR TITLE
fix(admin): real popup modal for primary admin email, toast on bulk actions

### DIFF
--- a/src/pages/workspace/admin/Admins.vue
+++ b/src/pages/workspace/admin/Admins.vue
@@ -380,6 +380,32 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 14, 25, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 1000;
+}
+
+.modal {
+  width: min(680px, 100%);
+  max-height: 90vh;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  padding: 1rem;
+}
+
+.modal h3 {
+  margin-top: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
 .admin-email-cell {
   display: inline-flex;
   align-items: center;

--- a/src/pages/workspace/admin/Borrowers.vue
+++ b/src/pages/workspace/admin/Borrowers.vue
@@ -402,10 +402,12 @@ const applyBulkAccess = async () => {
       await updateBorrowerAccess({ id, access_mode: accessMode, profile_ids: bulkAccessProfileIds.value });
     }
     success.value = "Tenant account access updated.";
+    showToast("Access updated", "Tenant account access updated for the selected borrowers.");
     showBulkAccessModal.value = false;
     selectedBorrowerIds.value = new Set();
   } catch (err) {
     error.value = err instanceof Error ? err.message : "Unable to update tenant account access.";
+    showToast("Update failed", error.value);
   } finally {
     isSaving.value = false;
   }
@@ -424,9 +426,11 @@ const applyBulkArchive = async () => {
       archivedBorrowers.value = [item, ...archivedBorrowers.value];
     }
     success.value = "Selected borrowers archived.";
+    showToast("Borrowers archived", `${targets.length} borrower(s) archived.`);
     selectedBorrowerIds.value = new Set();
   } catch (err) {
     error.value = err instanceof Error ? err.message : "Unable to archive selected borrowers.";
+    showToast("Archive failed", error.value);
   } finally {
     isSaving.value = false;
   }

--- a/src/pages/workspace/admin/Items.vue
+++ b/src/pages/workspace/admin/Items.vue
@@ -511,10 +511,12 @@ const applyBulkAccess = async () => {
       items.value = items.value.map((row) => (row.id === updated.id ? updated : row));
     }
     success.value = "Tenant account access updated.";
+    showToast("Access updated", "Tenant account access updated for the selected items.");
     showBulkAccessModal.value = false;
     selectedItemIds.value = new Set();
   } catch (err) {
     error.value = toUserFacingErrorMessage(err, "Unable to update tenant account access.");
+    showToast("Update failed", error.value);
   } finally {
     isSaving.value = false;
   }
@@ -537,10 +539,12 @@ const applyBulkStatus = async () => {
       items.value = items.value.map((row) => (row.id === updated.id ? updated : row));
     }
     success.value = "Status updated.";
+    showToast("Status updated", "Status updated for the selected items.");
     bulkStatusValue.value = "";
     selectedItemIds.value = new Set();
   } catch (err) {
     error.value = toUserFacingErrorMessage(err, "Unable to update status.");
+    showToast("Update failed", error.value);
   } finally {
     isSaving.value = false;
   }
@@ -559,9 +563,11 @@ const applyBulkArchive = async () => {
       archivedItem.value = [item, ...archivedItem.value];
     }
     success.value = "Selected items archived.";
+    showToast("Items archived", `${targets.length} item(s) archived.`);
     selectedItemIds.value = new Set();
   } catch (err) {
     error.value = err instanceof Error ? err.message : "Unable to archive selected items.";
+    showToast("Archive failed", error.value);
   } finally {
     isSaving.value = false;
   }


### PR DESCRIPTION
…ctions

Admins.vue was missing scoped .modal-backdrop/.modal CSS so the primary admin email popup rendered inline instead of as an overlay. Bulk access/ status/archive actions in Borrowers.vue and Items.vue set a success/error ref far from the bulk action bar with no visible feedback; wired existing bottom-right toast into all handlers.