### PR TITLE
Implement least-privilege access for PostgREST and Data API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Changelog
 
-Last updated (year-month-day): 2026-07-25
+Last updated (year-month-day): 2026-07-26
 
 This changelog summarizes notable ItemTraxx product, reliability, security, and experience updates.
 
 Changes are dated based on the default timezone: America/Los_Angeles
 
 ---
+
+### 7/26/2026 Development Update
+
+- Strengthened database permissions so records can only be changed through verified server paths.
+- Admin actions now confirm recent sign-in on the server, matching the existing admin verification prompt.
+- Narrowed the data gateway to only the records the app actually uses.
+- Improved status page efficiency with short-term caching and request limits.
+- Expanded automated security checks in CI.
 
 ### 7/25/2026 Development Update
 

--- a/cloudflare/edge-proxy/src/index.ts
+++ b/cloudflare/edge-proxy/src/index.ts
@@ -12,6 +12,8 @@ import { buildError, buildJson } from "./responses.ts";
 import {
   getFunctionName,
   getSessionAction,
+  isAllowedRestRequest,
+  isAllowedRpcProxyPath,
   isBlockedRpcProxyPath,
   isRestProxyPath,
   isRpcProxyPath,
@@ -107,6 +109,15 @@ export default {
           request.headers.get("x-itx-data-request") !== "1"
         ) {
           return buildError(400, "Invalid data request", headers, requestId);
+        }
+        // Table/method allowlist for the PostgREST pass-through. RPC paths keep
+        // their own allowlist (checked above); everything else must be a
+        // relation the SPA actually uses, so schema-level privilege drift
+        // cannot become a browser-reachable data path.
+        const isRpcPath = isRpcProxyPath(url.pathname) ||
+          isAllowedRpcProxyPath(url.pathname);
+        if (!isRpcPath && !isAllowedRestRequest(url.pathname, request.method)) {
+          return buildError(403, "Data request not allowed", headers, requestId);
         }
         const response = await proxySupabaseApiRequest(
           request,

--- a/cloudflare/edge-proxy/src/index_contract_test.ts
+++ b/cloudflare/edge-proxy/src/index_contract_test.ts
@@ -403,7 +403,7 @@ Deno.test("Data API mutations require the explicit mutation header", async () =>
   }) as typeof fetch;
   try {
     const rejected = await worker.fetch(
-      new Request("https://edge.itemtraxx.com/rest/v1/items", {
+      new Request("https://edge.itemtraxx.com/rest/v1/admin_audit_logs", {
         method: "POST",
         headers: { origin: ORIGIN, authorization: "Bearer caller" },
         body: "fixture",
@@ -413,8 +413,27 @@ Deno.test("Data API mutations require the explicit mutation header", async () =>
     );
     assertEquals(rejected.status, 400, "missing data mutation header");
 
-    const allowed = await worker.fetch(
+    // items is deliberately not writable through the Data API proxy: item
+    // mutations must go through admin-item-mutate, which enforces barcode
+    // format, the checkout guards, soft-delete semantics, and audit logging.
+    const notWritable = await worker.fetch(
       new Request("https://edge.itemtraxx.com/rest/v1/items", {
+        method: "POST",
+        headers: {
+          origin: ORIGIN,
+          authorization: "Bearer caller",
+          "content-type": "application/octet-stream",
+          "x-itx-data-request": "1",
+        },
+        body: "fixture",
+      }),
+      baseEnv(),
+      createContext().ctx,
+    );
+    assertEquals(notWritable.status, 403, "unlisted table write is refused");
+
+    const allowed = await worker.fetch(
+      new Request("https://edge.itemtraxx.com/rest/v1/admin_audit_logs", {
         method: "POST",
         headers: {
           origin: ORIGIN,

--- a/cloudflare/edge-proxy/src/routing.ts
+++ b/cloudflare/edge-proxy/src/routing.ts
@@ -18,6 +18,42 @@ export const getSessionAction = (pathname: string) =>
 export const isRestProxyPath = (pathname: string) =>
   pathname.startsWith("/rest/v1/");
 
+// The SPA reaches PostgREST through exactly one client
+// (src/services/authenticatedDataClient.ts) and touches a small, fixed set of
+// relations. Enumerating them here keeps the proxy from being a generic
+// database gateway: a future over-broad GRANT or policy is no longer reachable
+// from a browser just because it exists in the schema.
+const READABLE_REST_TABLES = new Set([
+  "items",
+  "borrowers",
+  "item_logs",
+  "item_access_grants",
+  "borrower_access_grants",
+  "profiles",
+  "workspaces",
+]);
+
+// admin_audit_logs is the one relation the browser writes directly
+// (src/services/auditLogService.ts). Its INSERT policy pins actor_id to
+// auth.uid() and the row's workspace, and no UPDATE/DELETE policy exists.
+const WRITABLE_REST_TABLES = new Set(["admin_audit_logs"]);
+
+export const getRestTableName = (pathname: string) =>
+  readExactSegment(pathname, "/rest/v1/");
+
+export const isAllowedRestRequest = (pathname: string, method: string) => {
+  const table = getRestTableName(pathname);
+  if (!table) return false;
+  const normalizedMethod = method.toUpperCase();
+  if (normalizedMethod === "GET" || normalizedMethod === "HEAD") {
+    return READABLE_REST_TABLES.has(table) || WRITABLE_REST_TABLES.has(table);
+  }
+  if (normalizedMethod === "POST") {
+    return WRITABLE_REST_TABLES.has(table);
+  }
+  return false;
+};
+
 export const isRpcProxyPath = (pathname: string) =>
   pathname === "/rpc" || pathname.startsWith("/rpc/");
 

--- a/cloudflare/edge-proxy/src/routing_test.ts
+++ b/cloudflare/edge-proxy/src/routing_test.ts
@@ -1,7 +1,9 @@
 import {
   getFunctionName,
+  getRestTableName,
   getRpcFunctionName,
   getSessionAction,
+  isAllowedRestRequest,
   isAllowedRpcProxyPath,
   isBlockedRpcProxyPath,
   isRestProxyPath,
@@ -262,5 +264,74 @@ Deno.test("deep percent nesting fails closed within a bounded routing budget", (
     `deeply nested RPC detection exceeded its 100ms budget: ${
       elapsedMs.toFixed(1)
     }ms`,
+  );
+});
+
+Deno.test("REST allowlist admits only the relations and methods the SPA uses", () => {
+  const readable = [
+    "items",
+    "borrowers",
+    "item_logs",
+    "item_access_grants",
+    "borrower_access_grants",
+    "profiles",
+    "workspaces",
+    "admin_audit_logs",
+  ];
+  for (const table of readable) {
+    assert(
+      isAllowedRestRequest(`/rest/v1/${table}`, "GET"),
+      `${table} must stay readable`,
+    );
+    assert(
+      isAllowedRestRequest(`/rest/v1/${table}`, "HEAD"),
+      `${table} must stay countable`,
+    );
+  }
+
+  assert(
+    isAllowedRestRequest("/rest/v1/admin_audit_logs", "POST"),
+    "browser audit-log insert must stay allowed",
+  );
+  assert(
+    !isAllowedRestRequest("/rest/v1/items", "POST"),
+    "item writes must go through admin-item-mutate",
+  );
+  assert(
+    !isAllowedRestRequest("/rest/v1/borrowers", "PATCH"),
+    "borrower writes must go through admin-borrower-mutate",
+  );
+  assert(
+    !isAllowedRestRequest("/rest/v1/workspace_policies", "PATCH"),
+    "entitlement writes must go through admin-ops/super-ops",
+  );
+  assert(
+    !isAllowedRestRequest("/rest/v1/admin_audit_logs", "DELETE"),
+    "audit rows must not be deletable from a browser",
+  );
+});
+
+Deno.test("REST allowlist rejects unlisted, nested, and encoded relation names", () => {
+  for (const path of [
+    "/rest/v1/super_admin_sessions",
+    "/rest/v1/privileged_session_stepups",
+    "/rest/v1/account_sessions",
+    "/rest/v1/workspace_security_controls",
+    "/rest/v1/rpc/run_data_retention",
+    "/rest/v1/items/extra",
+    "/rest/v1/it%65ms",
+    "/rest/v1/",
+  ]) {
+    assert(
+      !isAllowedRestRequest(path, "GET"),
+      `unlisted or non-canonical path must be denied: ${path}`,
+    );
+  }
+
+  assertEquals(getRestTableName("/rest/v1/items"), "items", "table extraction");
+  assertEquals(
+    getRestTableName("/rest/v1/rpc/consume_rate_limit"),
+    "",
+    "rpc subpaths are not tables",
   );
 });

--- a/cloudflare/edge-proxy/src/session.ts
+++ b/cloudflare/edge-proxy/src/session.ts
@@ -141,6 +141,17 @@ const hasActiveApplicationSession = async (
   accessToken: string,
   profile: ProfileRow,
 ) => {
+  // Super admins have no account_sessions row -- their device sessions live in
+  // super_admin_sessions, which the `authenticated` role cannot read, so the
+  // worker cannot consult it with the caller's own token. Refreshing is
+  // therefore allowed here on role alone; revocation is enforced where it
+  // grants access rather than where it mints a token:
+  //   - RLS: every super_admin_* policy requires
+  //     private.super_admin_session_not_revoked() and a live step-up
+  //     (20260726120000_least_privilege_rest_surface.sql)
+  //   - edge functions: isSuperAdminTokenBlockedBySessionRevocation() on every
+  //     super-* entrypoint
+  // A refreshed token for a revoked super admin therefore opens nothing.
   if (profile.role === "super_admin") return true;
   const sessionId = readJwtSessionId(accessToken);
   if (!sessionId) return false;

--- a/scripts/check-privileged-rls-policies.mjs
+++ b/scripts/check-privileged-rls-policies.mjs
@@ -1,112 +1,229 @@
 import { readFileSync } from "node:fs";
 
-const migrationPath = new URL(
-  "../supabase/migrations/20260725221011_item_borrower_physical_rename.sql",
-  import.meta.url,
-);
-const migration = readFileSync(migrationPath, "utf8");
+// Static guard over the migrations that define the browser-reachable database
+// surface. This exists because the workspace-model redesign silently widened
+// that surface -- it granted `authenticated` table-wide write privileges and
+// dropped the step-up predicate that every privileged policy used to carry --
+// and nothing in CI noticed. Each assertion below encodes one invariant that,
+// if it regresses, re-opens a finding from the July 2026 security audit.
+//
+// The checks are textual because CI has no database. They verify what the
+// migrations declare, not what production actually has; see
+// ITEMTRAXX_SECURITY_AUDIT.md section 9 for that limitation.
+
+const readMigration = (name) =>
+  readFileSync(new URL(`../supabase/migrations/${name}`, import.meta.url), "utf8");
+
+const RENAME_MIGRATION = "20260725221011_item_borrower_physical_rename.sql";
+const LEAST_PRIVILEGE_MIGRATION = "20260726120000_least_privilege_rest_surface.sql";
+
+const renameMigration = readMigration(RENAME_MIGRATION);
+const leastPrivilege = readMigration(LEAST_PRIVILEGE_MIGRATION);
+
+const failures = [];
+const check = (condition, message) => {
+  if (!condition) failures.push(message);
+};
 
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-const policyPattern = (prefix, policyName) =>
-  new RegExp(
-    `${prefix}\\s+policy\\s+${prefix === "drop" ? "(?:if\\s+exists\\s+)?" : ""}(?:"${escapeRegExp(policyName)}"|${escapeRegExp(policyName)})\\s+on\\s+public\\.`,
-    "i",
-  );
+const normalizeSql = (value) =>
+  value.replace(/\s+/g, " ").replace(/\s*=\s*/g, "=").trim().toLowerCase();
 
-const requireDroppedOnly = (policyName) => {
-  if (!policyPattern("drop", policyName).test(migration)) {
-    throw new Error(`final RLS migration does not drop legacy policy ${policyName}`);
-  }
-  if (policyPattern("create", policyName).test(migration)) {
-    throw new Error(`final RLS migration recreates unsafe policy ${policyName}`);
-  }
-};
-
-const extractParenthesizedClause = (statement, keyword) => {
-  const keywordIndex = statement.toLowerCase().indexOf(keyword);
-  const openIndex = statement.indexOf("(", keywordIndex + keyword.length);
-  if (keywordIndex === -1 || openIndex === -1) {
-    return null;
-  }
-
-  let depth = 0;
-  for (let index = openIndex; index < statement.length; index += 1) {
-    if (statement[index] === "(") {
-      depth += 1;
-    } else if (statement[index] === ")") {
-      depth -= 1;
-      if (depth === 0) {
-        return statement.slice(openIndex + 1, index);
-      }
-    }
-  }
-
-  return null;
-};
-
-const normalizeSql = (value) => value
-  .replace(/\s+/g, " ")
-  .replace(/\s*=\s*/g, "=")
-  .trim()
-  .toLowerCase();
-
-const requireStepUpPolicy = (policyName, tableName) => {
-  const statement = migration.match(
+// ---------------------------------------------------------------------------
+// 1. Member SELECT policies must keep enforcing workspace scope and an active
+//    session. These are the policies the SPA actually reads through, so they
+//    are the ones that must never loosen.
+// ---------------------------------------------------------------------------
+const extractPolicyStatement = (sql, policyName, tableName) =>
+  sql.match(
     new RegExp(
       `create\\s+policy\\s+(?:"${escapeRegExp(policyName)}"|${escapeRegExp(policyName)})\\s+on\\s+public\\.${escapeRegExp(tableName)}[\\s\\S]*?;`,
       "i",
     ),
-  )?.[0];
+  )?.[0] ?? null;
 
+const requireMemberSelectPolicy = (policyName, tableName) => {
+  const statement = extractPolicyStatement(renameMigration, policyName, tableName);
   if (!statement) {
-    throw new Error(`final RLS migration does not create ${policyName}`);
+    failures.push(`${RENAME_MIGRATION} no longer creates ${policyName}`);
+    return;
   }
-
-  if (!/\bfor\s+all\s+to\s+authenticated\b/i.test(statement)) {
-    throw new Error(`${policyName} must be FOR ALL TO authenticated`);
-  }
-
-  const usingClause = extractParenthesizedClause(statement, "using");
-  const withCheckClause = extractParenthesizedClause(statement, "with check");
-  if (!usingClause) {
-    throw new Error(`${policyName} is missing USING`);
-  }
-  if (!withCheckClause) {
-    throw new Error(`${policyName} is missing WITH CHECK`);
-  }
-
-  const requiredPredicates = [
-    /current_user_role\(\)\)\s*=\s*'workspace_admin'/i,
-    /workspace_id\s*=\s*\(select\s+public\.current_workspace_id\(\)\)/i,
-    /private\.current_account_session_is_active\(\)/i,
-  ];
-
-  for (const predicate of requiredPredicates) {
-    if (!predicate.test(usingClause) || !predicate.test(withCheckClause)) {
-      throw new Error(
-        `${policyName} must enforce ${predicate} in both USING and WITH CHECK`,
-      );
-    }
-  }
-
-  const expectedClause = [
-    "(select public.current_user_role())='workspace_admin'",
-    "workspace_id=(select public.current_workspace_id())",
-    "(select private.current_account_session_is_active())",
-  ].join(" and ");
-
-  if (
-    normalizeSql(usingClause) !== normalizeSql(expectedClause) ||
-    normalizeSql(withCheckClause) !== normalizeSql(expectedClause)
+  check(
+    /\bfor\s+select\s+to\s+authenticated\b/i.test(statement),
+    `${policyName} must remain FOR SELECT TO authenticated`,
+  );
+  for (
+    const [label, predicate] of [
+      ["workspace scope", /workspace_id\s*=\s*\(select\s+public\.current_workspace_id\(\)\)/i],
+      ["active session", /private\.current_account_session_is_active\(\)/i],
+      ["soft-delete filter", /deleted_at\s+is\s+null/i],
+    ]
   ) {
-    throw new Error(
-      `${policyName} must AND-connect only the Workspace Admin, workspace, and active-session predicates in both USING and WITH CHECK`,
-    );
+    check(predicate.test(statement), `${policyName} must enforce ${label}`);
   }
 };
 
-requireStepUpPolicy("workspace_admin_write_items", "items");
-requireStepUpPolicy("workspace_admin_write_borrowers", "borrowers");
+requireMemberSelectPolicy("workspace_members_select_items", "items");
+requireMemberSelectPolicy("workspace_members_select_borrowers", "borrowers");
 
-console.log("Item/borrower RLS policies require Workspace Admin role, workspace scope, and an active session.");
+// ---------------------------------------------------------------------------
+// 2. The workspace-admin direct write path must stay closed. These policies and
+//    grants let a workspace admin bypass admin-item-mutate / admin-borrower-mutate
+//    (validation, checkout guards, soft delete, audit logging) and rewrite
+//    workspace_policies entitlements with a single PATCH.
+// ---------------------------------------------------------------------------
+for (
+  const [policyName, tableName] of [
+    ["workspace_admin_write_items", "items"],
+    ["workspace_admin_write_borrowers", "borrowers"],
+    ["workspace_admin_write_policies", "workspace_policies"],
+    ["workspace_admin_write_item_status_history", "item_status_history"],
+    ["access_grants_workspace_admin_all_items", "item_access_grants"],
+    ["access_grants_workspace_admin_all_borrowers", "borrower_access_grants"],
+  ]
+) {
+  check(
+    new RegExp(
+      `drop\\s+policy\\s+if\\s+exists\\s+${escapeRegExp(policyName)}\\s+on\\s+public\\.${escapeRegExp(tableName)}`,
+      "i",
+    ).test(leastPrivilege),
+    `${LEAST_PRIVILEGE_MIGRATION} must drop the direct-write policy ${policyName}`,
+  );
+  check(
+    !extractPolicyStatement(leastPrivilege, policyName, tableName),
+    `${LEAST_PRIVILEGE_MIGRATION} must not recreate the direct-write policy ${policyName}`,
+  );
+}
+
+for (
+  const table of [
+    "workspace_policies",
+    "items",
+    "borrowers",
+    "item_status_history",
+    "item_access_grants",
+    "borrower_access_grants",
+  ]
+) {
+  check(
+    new RegExp(
+      `revoke\\s+insert,\\s*update,\\s*delete\\s+on\\s+public\\.${escapeRegExp(table)}\\s+from\\s+authenticated`,
+      "i",
+    ).test(leastPrivilege),
+    `${LEAST_PRIVILEGE_MIGRATION} must revoke write privileges on ${table} from authenticated`,
+  );
+}
+
+check(
+  /revoke\s+update,\s*delete\s+on\s+public\.admin_audit_logs\s+from\s+authenticated/i.test(leastPrivilege),
+  `${LEAST_PRIVILEGE_MIGRATION} must revoke update/delete on admin_audit_logs from authenticated`,
+);
+
+// The browser audit-log insert (src/services/auditLogService.ts) is the one
+// write that must survive. Guard against an over-broad future revoke.
+check(
+  !/revoke[^;]*\binsert\b[^;]*on\s+public\.admin_audit_logs\s+from\s+authenticated/i.test(leastPrivilege),
+  `${LEAST_PRIVILEGE_MIGRATION} must not revoke INSERT on admin_audit_logs (breaks auditLogService.ts)`,
+);
+
+// ---------------------------------------------------------------------------
+// 3. Access-grant tables keep a read path. Dropping these outright would break
+//    the admin Items/Borrowers access pickers, which read them directly.
+// ---------------------------------------------------------------------------
+for (
+  const [policyName, tableName] of [
+    ["access_grants_workspace_admin_select_items", "item_access_grants"],
+    ["access_grants_workspace_admin_select_borrowers", "borrower_access_grants"],
+  ]
+) {
+  const statement = extractPolicyStatement(leastPrivilege, policyName, tableName);
+  if (!statement) {
+    failures.push(`${LEAST_PRIVILEGE_MIGRATION} must create ${policyName}`);
+    continue;
+  }
+  check(
+    /\bfor\s+select\s+to\s+authenticated\b/i.test(statement),
+    `${policyName} must be FOR SELECT TO authenticated`,
+  );
+  check(
+    /private\.current_account_session_is_active\(\)/i.test(statement),
+    `${policyName} must enforce an active session`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Super-admin policies must require a live step-up and a non-revoked
+//    session, so the RLS path matches what every super-* edge function checks.
+// ---------------------------------------------------------------------------
+const SUPER_ADMIN_POLICIES = [
+  "super_admin_all_workspaces",
+  "super_admin_all_profiles",
+  "super_admin_all_items",
+  "super_admin_all_borrowers",
+  "super_admin_all_item_logs",
+  "super_admin_all_item_status_history",
+  "super_admin_all_policies",
+  "super_admin_all_security_controls",
+  "super_admin_all_audit",
+];
+
+for (const policyName of SUPER_ADMIN_POLICIES) {
+  check(
+    new RegExp(`'${escapeRegExp(policyName)}'`).test(leastPrivilege),
+    `${LEAST_PRIVILEGE_MIGRATION} must rebuild ${policyName}`,
+  );
+}
+
+const superAdminPolicyBody = leastPrivilege.match(
+  /create\s+policy\s+%I\s+on\s+public\.%I[\s\S]*?\$fmt\$/i,
+)?.[0];
+
+if (!superAdminPolicyBody) {
+  failures.push(
+    `${LEAST_PRIVILEGE_MIGRATION} must contain the templated super-admin policy body`,
+  );
+} else {
+  const normalized = normalizeSql(superAdminPolicyBody);
+  const roleChecks = (normalized.match(/current_user_role\(\)\)='super_admin'/g) ?? []).length;
+  const stepUpChecks = (normalized.match(/has_recent_privileged_step_up\('super_admin'\)/g) ?? []).length;
+  const revocationChecks = (normalized.match(/super_admin_session_not_revoked\(\)/g) ?? []).length;
+
+  // Twice each: once in USING, once in WITH CHECK.
+  check(roleChecks >= 2, "super-admin policy body must check the role in USING and WITH CHECK");
+  check(stepUpChecks >= 2, "super-admin policy body must require step-up in USING and WITH CHECK");
+  check(
+    revocationChecks >= 2,
+    "super-admin policy body must require a non-revoked session in USING and WITH CHECK",
+  );
+}
+
+check(
+  /create\s+or\s+replace\s+function\s+private\.super_admin_session_not_revoked\(\)/i.test(leastPrivilege),
+  `${LEAST_PRIVILEGE_MIGRATION} must define private.super_admin_session_not_revoked()`,
+);
+
+check(
+  !/when\s+\(select\s+public\.current_user_role\(\)\)\s*=\s*'super_admin'\s*then\s+true/i.test(leastPrivilege),
+  "private.current_account_session_is_active() must not return an unconditional true for super admins",
+);
+
+// ---------------------------------------------------------------------------
+
+if (failures.length > 0) {
+  console.error("Privileged RLS invariants failed:");
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  [
+    "Privileged RLS invariants hold:",
+    "- workspace member SELECT policies enforce workspace scope, active session, and soft-delete filtering",
+    "- workspace-admin direct write policies and grants are removed on items, borrowers,",
+    "  item_status_history, workspace_policies, and both access-grant tables",
+    "- admin_audit_logs keeps INSERT for the browser audit path and nothing else",
+    "- access-grant read paths are preserved as FOR SELECT",
+    `- all ${SUPER_ADMIN_POLICIES.length} super-admin policies require step-up and a non-revoked session`,
+  ].join("\n"),
+);

--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -32,6 +32,7 @@ echo "[security] running Supabase shared security regression tests"
 deno test --allow-env \
   supabase/functions/_shared/cors_test.ts \
   supabase/functions/_shared/accountSessions_test.ts \
+  supabase/functions/_shared/adminReauth_test.ts \
   supabase/functions/_shared/preloginGuards_test.ts \
   supabase/functions/_shared/trustedIngress_test.ts
 

--- a/supabase/functions/_shared/adminReauth.ts
+++ b/supabase/functions/_shared/adminReauth.ts
@@ -1,0 +1,115 @@
+// Server-side enforcement of the Workspace Admin re-authentication window.
+//
+// The product presents /admin/login as a verification step before admin
+// functions become available, and the SPA enforces a 15-minute freshness
+// window on it (src/router/index.ts hasFreshAdminVerification, fed by
+// authState.adminVerifiedAt <- session summary password_authenticated_at).
+// Until now that window existed only in the browser: the admin edge functions
+// checked role and device session but never how recently the caller actually
+// authenticated, so the gate could be skipped by calling the API directly.
+//
+// This module re-derives the same fact the client is already relying on --
+// "when did this session last complete an interactive authentication?" -- from
+// the verified JWT, so the control holds on the server too.
+//
+// Deliberately NOT applied to: session lifecycle actions (touch/validate/list/
+// revoke), which the app polls continuously and which must keep working for a
+// user to sign themselves out, and checkoutReturn, which is the daily-driver
+// workflow for both roles.
+
+type ClaimsClient = {
+  auth: {
+    getClaims: (token: string) => Promise<{
+      data: { claims: Record<string, unknown> } | null;
+      error: unknown | null;
+    }>;
+  };
+};
+
+export const ADMIN_REAUTH_MAX_AGE_MS = 15 * 60 * 1000;
+
+// Small tolerance for clock skew between the auth server and this runtime, so a
+// token minted moments ago is never treated as issued in the future.
+const CLOCK_SKEW_TOLERANCE_MS = 30 * 1000;
+
+/**
+ * Most recent `amr` (authentication methods reference) timestamp in the token.
+ *
+ * Any interactive method counts -- password, magic link, OTP, passkey -- because
+ * the control is "the human re-authenticated recently", not "the human used a
+ * password". Restricting this to `password` would lock out any future
+ * magic-link or passkey admin sign-in. Token refresh does not add `amr`
+ * entries, so this does not drift with session age.
+ */
+export const readLatestAuthTimestampMs = (
+  claims: Record<string, unknown>,
+): number | null => {
+  const amr = claims.amr;
+  if (!Array.isArray(amr)) return null;
+
+  let latest: number | null = null;
+  for (const entry of amr) {
+    if (!entry || typeof entry !== "object") continue;
+    const timestamp = (entry as { timestamp?: unknown }).timestamp;
+    if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) continue;
+    if (timestamp <= 0) continue;
+    const timestampMs = timestamp * 1000;
+    if (latest === null || timestampMs > latest) latest = timestampMs;
+  }
+  return latest;
+};
+
+export type AdminReauthResult =
+  | { fresh: true }
+  | { fresh: false; reason: "unverified" | "no_auth_timestamp" | "stale" };
+
+/**
+ * Fails closed: an unverifiable token, or one carrying no usable authentication
+ * timestamp, is treated as not re-authenticated.
+ */
+export const checkRecentAdminAuth = async (
+  authClient: ClaimsClient,
+  authToken: string,
+  maxAgeMs: number = ADMIN_REAUTH_MAX_AGE_MS,
+): Promise<AdminReauthResult> => {
+  const { data, error } = await authClient.auth.getClaims(authToken);
+  if (error || !data?.claims) {
+    return { fresh: false, reason: "unverified" };
+  }
+
+  const authenticatedAtMs = readLatestAuthTimestampMs(data.claims);
+  if (authenticatedAtMs === null) {
+    return { fresh: false, reason: "no_auth_timestamp" };
+  }
+
+  const ageMs = Date.now() - authenticatedAtMs;
+  if (ageMs > maxAgeMs || ageMs < -CLOCK_SKEW_TOLERANCE_MS) {
+    return { fresh: false, reason: "stale" };
+  }
+  return { fresh: true };
+};
+
+// Matches the guard contract the SPA already implements and the E2E suite
+// already asserts: tests/e2e/admin-mutation-guards.spec.ts models
+// `step_up_required` as 403 with exactly this message. Using 401 instead would
+// trigger the token-refresh retry in src/services/edgeFunctionClient.ts:160,
+// which cannot help -- a refreshed token carries the same amr timestamps.
+export const ADMIN_REAUTH_REQUIRED_STATUS = 403;
+export const ADMIN_REAUTH_REQUIRED_MESSAGE = "Admin verification required.";
+
+/**
+ * Returns a 403 response when the caller has not re-authenticated recently, or
+ * null to continue.
+ */
+export const requireRecentAdminAuth = async (
+  authClient: ClaimsClient,
+  authToken: string,
+  jsonResponse: (status: number, body: Record<string, unknown>) => Response,
+  maxAgeMs: number = ADMIN_REAUTH_MAX_AGE_MS,
+): Promise<Response | null> => {
+  const result = await checkRecentAdminAuth(authClient, authToken, maxAgeMs);
+  if (result.fresh) return null;
+  return jsonResponse(ADMIN_REAUTH_REQUIRED_STATUS, {
+    error: ADMIN_REAUTH_REQUIRED_MESSAGE,
+  });
+};

--- a/supabase/functions/_shared/adminReauth_test.ts
+++ b/supabase/functions/_shared/adminReauth_test.ts
@@ -1,0 +1,162 @@
+import {
+  ADMIN_REAUTH_MAX_AGE_MS,
+  checkRecentAdminAuth,
+  readLatestAuthTimestampMs,
+  requireRecentAdminAuth,
+} from "./adminReauth.ts";
+
+const assert = (condition: unknown, message: string) => {
+  if (!condition) throw new Error(message);
+};
+
+const assertEquals = (actual: unknown, expected: unknown, message: string) => {
+  if (actual !== expected) {
+    throw new Error(
+      `${message}: expected ${String(expected)}, received ${String(actual)}`,
+    );
+  }
+};
+
+const secondsAgo = (seconds: number) =>
+  Math.floor((Date.now() - seconds * 1000) / 1000);
+
+const claimsClient = (
+  claims: Record<string, unknown> | null,
+  error: unknown = null,
+) => ({
+  auth: {
+    getClaims: () =>
+      Promise.resolve({
+        data: claims ? { claims } : null,
+        error,
+      }),
+  },
+});
+
+const jsonResponse = (status: number, body: Record<string, unknown>) =>
+  new Response(JSON.stringify(body), { status });
+
+Deno.test("latest amr timestamp wins across multiple authentication methods", () => {
+  const latest = readLatestAuthTimestampMs({
+    amr: [
+      { method: "password", timestamp: secondsAgo(600) },
+      { method: "magiclink", timestamp: secondsAgo(60) },
+    ],
+  });
+  assert(latest !== null, "a timestamp must be resolved");
+  const ageMs = Date.now() - (latest as number);
+  assert(
+    ageMs < 90_000,
+    `most recent method must win, resolved age was ${ageMs}ms`,
+  );
+});
+
+Deno.test("malformed amr entries never produce a usable timestamp", () => {
+  for (
+    const claims of [
+      {},
+      { amr: null },
+      { amr: "password" },
+      { amr: [] },
+      { amr: [null, "password", 42] },
+      { amr: [{ method: "password" }] },
+      { amr: [{ method: "password", timestamp: "recent" }] },
+      { amr: [{ method: "password", timestamp: 0 }] },
+      { amr: [{ method: "password", timestamp: Number.NaN }] },
+    ]
+  ) {
+    assertEquals(
+      readLatestAuthTimestampMs(claims as Record<string, unknown>),
+      null,
+      `malformed amr must not yield a timestamp: ${JSON.stringify(claims)}`,
+    );
+  }
+});
+
+Deno.test("a recent interactive authentication passes", async () => {
+  const result = await checkRecentAdminAuth(
+    claimsClient({ amr: [{ method: "password", timestamp: secondsAgo(60) }] }),
+    "token",
+  );
+  assert(result.fresh, "a 60s-old password authentication must be fresh");
+});
+
+Deno.test("passkey and magic-link sign-ins are accepted, not just passwords", async () => {
+  for (const method of ["magiclink", "otp", "passkey", "webauthn"]) {
+    const result = await checkRecentAdminAuth(
+      claimsClient({ amr: [{ method, timestamp: secondsAgo(30) }] }),
+      "token",
+    );
+    assert(result.fresh, `${method} sign-in must satisfy admin re-auth`);
+  }
+});
+
+Deno.test("an authentication older than the window is refused", async () => {
+  const result = await checkRecentAdminAuth(
+    claimsClient({
+      amr: [{
+        method: "password",
+        timestamp: secondsAgo(ADMIN_REAUTH_MAX_AGE_MS / 1000 + 60),
+      }],
+    }),
+    "token",
+  );
+  assert(!result.fresh, "a stale authentication must be refused");
+  assertEquals(result.fresh ? "" : result.reason, "stale", "reason");
+});
+
+Deno.test("admin re-auth fails closed on unverifiable or timestamp-free tokens", async () => {
+  const unverified = await checkRecentAdminAuth(
+    claimsClient(null, new Error("bad signature")),
+    "token",
+  );
+  assert(!unverified.fresh, "an unverifiable token must be refused");
+  assertEquals(
+    unverified.fresh ? "" : unverified.reason,
+    "unverified",
+    "reason",
+  );
+
+  const noTimestamp = await checkRecentAdminAuth(claimsClient({}), "token");
+  assert(!noTimestamp.fresh, "a token without amr must be refused");
+  assertEquals(
+    noTimestamp.fresh ? "" : noTimestamp.reason,
+    "no_auth_timestamp",
+    "reason",
+  );
+});
+
+Deno.test("a far-future authentication timestamp is refused", async () => {
+  const result = await checkRecentAdminAuth(
+    claimsClient({
+      amr: [{ method: "password", timestamp: secondsAgo(-3600) }],
+    }),
+    "token",
+  );
+  assert(!result.fresh, "a future-dated authentication must not be trusted");
+});
+
+Deno.test("requireRecentAdminAuth returns 401 only when the window has lapsed", async () => {
+  const allowed = await requireRecentAdminAuth(
+    claimsClient({ amr: [{ method: "password", timestamp: secondsAgo(10) }] }),
+    "token",
+    jsonResponse,
+  );
+  assertEquals(allowed, null, "a fresh session must not be blocked");
+
+  const blocked = await requireRecentAdminAuth(
+    claimsClient({ amr: [{ method: "password", timestamp: secondsAgo(3600) }] }),
+    "token",
+    jsonResponse,
+  );
+  assert(blocked !== null, "a stale session must be blocked");
+  // 403 matches the step_up_required contract in
+  // tests/e2e/admin-mutation-guards.spec.ts and avoids the pointless
+  // token-refresh retry that a 401 would trigger in edgeFunctionClient.
+  assertEquals(blocked?.status, 403, "status matches the guard contract");
+  assertEquals(
+    JSON.parse(await (blocked as Response).text()).error,
+    "Admin verification required.",
+    "message matches the guard contract",
+  );
+});

--- a/supabase/functions/admin-borrower-mutate/index.ts
+++ b/supabase/functions/admin-borrower-mutate/index.ts
@@ -4,6 +4,7 @@ import { isKillSwitchWriteBlocked } from "../_shared/killSwitch.ts";
 import { isAllowedOrigin, parseAllowedOrigins } from "../_shared/cors.ts";
 import { requireTrustedEdgeIngress } from "../_shared/trustedIngress.ts";
 import { validateAccountDeviceSession } from "../_shared/accountSessions.ts";
+import { requireRecentAdminAuth } from "../_shared/adminReauth.ts";
 import { readJsonBody } from "../_shared/requestBody.ts";
 import {
   optionalText,
@@ -563,6 +564,13 @@ serve(async (req) => {
       if (!activeSession.valid) {
         return jsonResponse(401, { error: "Session revoked" });
       }
+
+      const reauthFailure = await requireRecentAdminAuth(
+        adminClient,
+        authToken,
+        jsonResponse,
+      );
+      if (reauthFailure) return reauthFailure;
     }
 
     const { data: maintenanceRow } = await adminClient

--- a/supabase/functions/admin-item-mutate/index.ts
+++ b/supabase/functions/admin-item-mutate/index.ts
@@ -5,6 +5,7 @@ import { isAllowedOrigin, parseAllowedOrigins } from "../_shared/cors.ts";
 import { requireTrustedEdgeIngress } from "../_shared/trustedIngress.ts";
 import { resolveRateLimitResult } from "../_shared/preloginGuards.ts";
 import { validateAccountDeviceSession } from "../_shared/accountSessions.ts";
+import { requireRecentAdminAuth } from "../_shared/adminReauth.ts";
 import { readJsonBody } from "../_shared/requestBody.ts";
 import {
   BARCODE_PATTERN,
@@ -241,6 +242,13 @@ serve(async (req) => {
       if (!activeSession.valid) {
         return jsonResponse(401, { error: "Session revoked" });
       }
+
+      const reauthFailure = await requireRecentAdminAuth(
+        adminClient,
+        authToken,
+        jsonResponse,
+      );
+      if (reauthFailure) return reauthFailure;
     }
 
     const { data: maintenanceRow } = await adminClient

--- a/supabase/functions/admin-ops/actions/index.ts
+++ b/supabase/functions/admin-ops/actions/index.ts
@@ -1,3 +1,4 @@
+import { requireRecentAdminAuth } from "../../_shared/adminReauth.ts";
 import type {
   AdminOpsContext,
   JsonResponse,
@@ -49,6 +50,16 @@ const WORKSPACE_ADMIN_ONLY_ACTIONS = new Set<AdminOpsAction>([
   "bulk_import_items",
 ]);
 
+// Actions that change workspace state and therefore require the caller to have
+// authenticated interactively within the admin re-auth window. Session
+// lifecycle actions (touch/validate/list/revoke) are deliberately excluded:
+// touch/validate are polled continuously by useAdminSessionLifecycle, and a
+// user must always be able to sign themselves out of a device.
+const ADMIN_REAUTH_ACTIONS = new Set<AdminOpsAction>([
+  "update_workspace_settings",
+  "bulk_import_items",
+]);
+
 const SUSPENDED_TENANT_WRITE_ACTIONS = new Set<AdminOpsAction>([
   "update_workspace_settings",
   "revoke_session",
@@ -81,6 +92,14 @@ export const authorizeAdminOpsAction = async (input: {
     input.isWorkspaceSuspended
   ) {
     return input.jsonResponse(403, { error: "Workspace disabled" });
+  }
+  if (ADMIN_REAUTH_ACTIONS.has(input.action)) {
+    const reauthFailure = await requireRecentAdminAuth(
+      input.adminClient,
+      input.authToken,
+      input.jsonResponse,
+    );
+    if (reauthFailure) return reauthFailure;
   }
   return null;
 };

--- a/supabase/functions/system-status/index.ts
+++ b/supabase/functions/system-status/index.ts
@@ -6,6 +6,10 @@ import {
   resolveKillSwitchMessage,
 } from "../_shared/killSwitch.ts";
 import { isAllowedOrigin, parseAllowedOrigins } from "../_shared/cors.ts";
+import {
+  enforcePreloginRateLimit,
+  resolveClientFingerprint,
+} from "../_shared/preloginGuards.ts";
 import { resolveSystemStatusOverride } from "../_shared/systemStatusOverride.ts";
 
 const corsHeaders = {
@@ -51,6 +55,34 @@ type IncidentWidgetPayload = {
   in_progress_maintenances?: unknown[];
   scheduled_maintenances?: unknown[];
 };
+
+// This endpoint is intentionally public and unauthenticated -- the app shell
+// probes it before any session exists, and the synthetic uptime checks call it
+// from outside Cloudflare. What it should not be is a free amplifier: each
+// request otherwise cost a service-role DB probe, three app_runtime_config
+// reads, and an outbound incident.io fetch.
+//
+// Two bounds, neither of which changes the public contract:
+//   1. a short in-memory cache of the derived incident.io verdict, shared by
+//      every request an isolate serves;
+//   2. a generous per-IP rate limit, well above any legitimate prober.
+const INCIDENT_CACHE_TTL_MS = 20_000;
+const STATUS_RATE_LIMIT_PER_MINUTE = 60;
+
+type CachedIncidentStatus = {
+  status: "operational" | "degraded" | "down";
+  summary: string;
+  check: "ok" | "warn" | "unavailable";
+  fetchedAt: number;
+};
+
+let cachedIncidentStatus: CachedIncidentStatus | null = null;
+
+const readCachedIncidentStatus = () =>
+  cachedIncidentStatus &&
+    Date.now() - cachedIncidentStatus.fetchedAt < INCIDENT_CACHE_TTL_MS
+    ? cachedIncidentStatus
+    : null;
 
 const resolveIncidentStatus = (
   payload: IncidentWidgetPayload
@@ -138,6 +170,25 @@ serve(async (req) => {
     const adminClient = createClient(supabaseUrl, serviceKey, {
       auth: { persistSession: false },
     });
+
+    // Bound the unauthenticated request cost. Fails open: a limiter outage must
+    // never take the public status page down with it.
+    const rateLimit = await enforcePreloginRateLimit(
+      adminClient,
+      resolveClientFingerprint(req, req.headers.get("origin")),
+      "system-status",
+      STATUS_RATE_LIMIT_PER_MINUTE,
+      60
+    ).catch(() => ({ ok: true as const, error: null }));
+    if (!rateLimit.ok && !rateLimit.error) {
+      return jsonResponse(429, {
+        status: "unknown",
+        checks: { config: "ok", db: "unknown" },
+        incident_summary: "rate limited",
+        duration_ms: Date.now() - startedAt,
+        checked_at: new Date().toISOString(),
+      });
+    }
 
     const { error } = await adminClient
       .from("profiles")
@@ -228,7 +279,12 @@ serve(async (req) => {
       }
     }
 
-    if (incidentWidgetUrl) {
+    const cachedIncident = readCachedIncidentStatus();
+    if (incidentWidgetUrl && cachedIncident) {
+      incidentStatus = cachedIncident.status;
+      incidentSummary = cachedIncident.summary;
+      incidentCheck = cachedIncident.check;
+    } else if (incidentWidgetUrl) {
       try {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), 3500);
@@ -252,10 +308,24 @@ serve(async (req) => {
         incidentStatus = mapped.status;
         incidentSummary = mapped.summary;
         incidentCheck = mapped.status === "operational" ? "ok" : "warn";
+        cachedIncidentStatus = {
+          status: incidentStatus,
+          summary: incidentSummary,
+          check: incidentCheck,
+          fetchedAt: Date.now(),
+        };
       } catch (error) {
         incidentStatus = "operational";
         incidentSummary = "incident source unavailable";
         incidentCheck = "unavailable";
+        // Cache the failure too, so an incident.io outage does not turn into a
+        // per-request outbound retry storm.
+        cachedIncidentStatus = {
+          status: incidentStatus,
+          summary: incidentSummary,
+          check: incidentCheck,
+          fetchedAt: Date.now(),
+        };
         console.error("system-status incident.io fetch failed:", error);
       }
     }

--- a/supabase/functions/workspace-admin-mutate/index.ts
+++ b/supabase/functions/workspace-admin-mutate/index.ts
@@ -5,6 +5,7 @@ import { isAllowedOrigin, parseAllowedOrigins } from "../_shared/cors.ts";
 import { requireTrustedEdgeIngress } from "../_shared/trustedIngress.ts";
 import { readJsonBody } from "../_shared/requestBody.ts";
 import { validateAccountDeviceSession } from "../_shared/accountSessions.ts";
+import { requireRecentAdminAuth } from "../_shared/adminReauth.ts";
 import {
   optionalText,
   requireEmail,
@@ -50,6 +51,10 @@ const resolveResetRedirectTo = (req: Request) => {
 };
 
 const randomPassword = () => `${crypto.randomUUID()}-Aa1!`;
+const WORKSPACE_ADMIN_READ_ACTIONS = new Set([
+  "list_workspace_admins",
+  "list_tenant_accounts",
+]);
 const WORKSPACE_ADMIN_INVITE_ACCEPTED_MESSAGE =
   "If this email is eligible, a workspace admin invitation will be sent.";
 
@@ -212,6 +217,19 @@ serve(async (req) => {
     }
     if (!activeSession.valid) {
       return jsonResponse(401, { error: "Session revoked" });
+    }
+
+    // Admin management is the highest-impact workspace surface (creating admins,
+    // resetting Tenant Account passwords, removing accounts), so every mutation
+    // requires a recent interactive authentication. The two list actions are
+    // exempt so the admin screens still load and can prompt for re-auth.
+    if (!WORKSPACE_ADMIN_READ_ACTIONS.has(action)) {
+      const reauthFailure = await requireRecentAdminAuth(
+        adminClient,
+        authToken,
+        jsonResponse,
+      );
+      if (reauthFailure) return reauthFailure;
     }
 
     if (action === "list_workspace_admins") {

--- a/supabase/migrations/20260726120000_least_privilege_rest_surface.sql
+++ b/supabase/migrations/20260726120000_least_privilege_rest_surface.sql
@@ -1,0 +1,214 @@
+-- Security audit remediation: least-privilege on the browser-reachable
+-- PostgREST surface, and real enforcement of super-admin step-up + session
+-- revocation at the RLS layer.
+--
+-- Context. The workspace-model redesign (20260725194622) rebuilt every policy
+-- from scratch and, in the process, (a) granted the `authenticated` role
+-- table-wide INSERT/UPDATE/DELETE on the core workspace tables and (b) dropped
+-- the has_recent_privileged_step_up() predicate that supabase/sql/rbac_hardening.sql
+-- had carried in every privileged policy. Because the edge proxy exposes a
+-- generic /rest/v1/* pass-through, both became reachable from any browser
+-- holding a session cookie.
+--
+-- The application does not depend on any of the privileges revoked here. Every
+-- mutation already runs through an edge function on the service_role key, which
+-- bypasses RLS and re-derives authorization in TypeScript. The only browser
+-- write that survives is the admin_audit_logs insert in
+-- src/services/auditLogService.ts, which is deliberately preserved.
+--
+-- Read paths are explicitly preserved:
+--   items / borrowers          -> workspace_members_select_{items,borrowers}
+--                                 (every SPA read filters deleted_at is null;
+--                                  archived rows are served by admin-item-mutate
+--                                  `list_deleted` on the service role)
+--   item_access_grants         -> replaced FOR ALL with an equivalent FOR SELECT
+--   borrower_access_grants     -> replaced FOR ALL with an equivalent FOR SELECT
+--   item_status_history        -> workspace_admin_select_item_status_history
+--   workspace_policies         -> workspace_members_select_policies
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 1. Super-admin session revocation, enforceable from inside a policy.
+--
+-- Mirrors the semantics of _shared/superAdminSessions.ts
+-- isSuperAdminTokenBlockedBySessionRevocation(): a revoked row blocks the
+-- token, but the ABSENCE of a row does not. Absence is the normal state for a
+-- session that has just been created and has not yet been registered by
+-- super-ops `touch_session`, so failing closed on absence would lock out every
+-- fresh super-admin login.
+-- ---------------------------------------------------------------------------
+create or replace function private.super_admin_session_not_revoked()
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select not exists (
+    select 1
+    from public.super_admin_sessions s
+    where s.profile_id = (select auth.uid())
+      and s.revoked_at is not null
+      and (
+        s.auth_session_id = (select auth.jwt() ->> 'session_id')
+        or s.revoked_at >= to_timestamp(((select auth.jwt() ->> 'iat'))::double precision)
+      )
+  );
+$$;
+
+revoke all on function private.super_admin_session_not_revoked() from public, anon, authenticated;
+grant execute on function private.super_admin_session_not_revoked() to authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- 2. private.current_account_session_is_active() no longer returns an
+--    unconditional true for super admins.
+--
+-- The super_admin short-circuit made the one session predicate that every other
+-- role is subject to a no-op for the most privileged role. Workspace-scoped
+-- policies additionally require workspace_id = current_workspace_id(), which is
+-- NULL for a super admin, so this branch was never load-bearing for access --
+-- but it should not silently report "active" for a revoked session.
+-- ---------------------------------------------------------------------------
+create or replace function private.current_account_session_is_active()
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select case
+    when (select public.current_user_role()) = 'super_admin'
+      then (select private.super_admin_session_not_revoked())
+    else exists (
+      select 1
+      from public.account_sessions a
+      join auth.sessions s on s.id::text = a.auth_session_id
+      where a.profile_id = (select auth.uid())
+        and s.user_id = (select auth.uid())
+        and a.auth_session_id = (select auth.jwt() ->> 'session_id')
+        and a.revoked_at is null
+    )
+  end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Super-admin policies now require a live step-up and a non-revoked session.
+--
+-- Restores the control that supabase/sql/rbac_hardening.sql enforced before the
+-- redesign, and brings the RLS path in line with what every super-* edge
+-- function already checks (role + revocation + hasPrivilegedStepUp).
+--
+-- No SPA code path is affected: no super-admin page reads through PostgREST
+-- (verified -- all super pages call edge functions), and a super admin's own
+-- profile row is served by the role-independent self_select_profile policy.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  target record;
+begin
+  for target in
+    select * from (values
+      ('workspaces',                 'super_admin_all_workspaces'),
+      ('profiles',                   'super_admin_all_profiles'),
+      ('items',                      'super_admin_all_items'),
+      ('borrowers',                  'super_admin_all_borrowers'),
+      ('item_logs',                  'super_admin_all_item_logs'),
+      ('item_status_history',        'super_admin_all_item_status_history'),
+      ('workspace_policies',         'super_admin_all_policies'),
+      ('workspace_security_controls','super_admin_all_security_controls'),
+      ('admin_audit_logs',           'super_admin_all_audit')
+    ) as t(table_name, policy_name)
+  loop
+    execute format('drop policy if exists %I on public.%I', target.policy_name, target.table_name);
+    execute format($fmt$
+      create policy %I on public.%I
+      for all to authenticated
+      using (
+        (select public.current_user_role()) = 'super_admin'
+        and (select public.has_recent_privileged_step_up('super_admin'))
+        and (select private.super_admin_session_not_revoked())
+      )
+      with check (
+        (select public.current_user_role()) = 'super_admin'
+        and (select public.has_recent_privileged_step_up('super_admin'))
+        and (select private.super_admin_session_not_revoked())
+      )
+    $fmt$, target.policy_name, target.table_name);
+  end loop;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Remove the workspace-admin write path on workspace_policies.
+--
+-- workspace_policies holds super-admin-owned entitlements: plan_code,
+-- account_category, max_admins/max_items/max_borrowers, feature_flags, and
+-- billing metadata. The supported tenant-side write is admin-ops
+-- `update_workspace_settings`, which writes exactly checkout_due_hours on the
+-- service role. The FOR ALL policy plus a table-wide grant let a workspace admin
+-- rewrite every other column with a single PATCH.
+--
+-- SELECT is retained via workspace_members_select_policies; the SPA needs
+-- checkout_due_hours and feature_flags.
+-- ---------------------------------------------------------------------------
+drop policy if exists workspace_admin_write_policies on public.workspace_policies;
+revoke insert, update, delete on public.workspace_policies from authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 5. Remove the direct write path on items / borrowers / item_status_history.
+--
+-- admin-item-mutate and admin-borrower-mutate enforce barcode format, the
+-- status enum, the "return before changing checkout status" and "return before
+-- archiving" guards, soft-delete-only semantics, and a mandatory
+-- admin_audit_logs entry. A direct PostgREST write skipped all of it.
+-- ---------------------------------------------------------------------------
+drop policy if exists workspace_admin_write_items on public.items;
+drop policy if exists workspace_admin_write_borrowers on public.borrowers;
+drop policy if exists workspace_admin_write_item_status_history on public.item_status_history;
+
+revoke insert, update, delete on public.items from authenticated;
+revoke insert, update, delete on public.borrowers from authenticated;
+revoke insert, update, delete on public.item_status_history from authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 6. Access-grant tables: FOR ALL -> FOR SELECT.
+--
+-- These policies cannot simply be dropped: they are the only ones granting a
+-- workspace admin SELECT on the grant tables, which the admin Items/Borrowers
+-- access pickers read directly (Items.vue:693,855 / Borrowers.vue:521).
+-- Grant writes happen in admin-item-mutate/admin-borrower-mutate replaceAccess()
+-- on the service role.
+-- ---------------------------------------------------------------------------
+drop policy if exists access_grants_workspace_admin_all_items on public.item_access_grants;
+create policy access_grants_workspace_admin_select_items on public.item_access_grants
+for select to authenticated
+using (
+  (select public.current_user_role()) = 'workspace_admin'
+  and (select private.item_is_in_current_workspace(item_access_grants.item_id))
+  and (select private.current_account_session_is_active())
+);
+
+drop policy if exists access_grants_workspace_admin_all_borrowers on public.borrower_access_grants;
+create policy access_grants_workspace_admin_select_borrowers on public.borrower_access_grants
+for select to authenticated
+using (
+  (select public.current_user_role()) = 'workspace_admin'
+  and (select private.borrower_is_in_current_workspace(borrower_access_grants.borrower_id))
+  and (select private.current_account_session_is_active())
+);
+
+revoke insert, update, delete on public.item_access_grants from authenticated;
+revoke insert, update, delete on public.borrower_access_grants from authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 7. admin_audit_logs: keep the browser INSERT, drop everything else.
+--
+-- src/services/auditLogService.ts writes here directly and the insert policy
+-- already pins actor_id = auth.uid() and the workspace. There is no policy
+-- permitting UPDATE or DELETE, so these grants were unreachable privilege.
+-- ---------------------------------------------------------------------------
+revoke update, delete on public.admin_audit_logs from authenticated;
+
+notify pgrst, 'reload schema';
+
+commit;


### PR DESCRIPTION
This pull request strengthens the security of the browser-accessible database surface by narrowing REST API access to a strict allowlist, enforcing least-privilege policies in the database, and adding comprehensive tests and static checks to prevent privilege drift. It ensures that only necessary tables and methods are accessible from the browser, closes direct write paths that bypass business logic, and adds static guards to CI to detect future regressions. Several tests and scripts have been updated or added to enforce and verify these constraints.

**REST API hardening:**
* Introduced `isAllowedRestRequest` and related helpers in `cloudflare/edge-proxy/src/routing.ts` to restrict browser REST access to a fixed set of readable and writable tables, and only for allowed HTTP methods. Now, only the relations actually used by the SPA are reachable, and only `admin_audit_logs` is writable directly from the browser.
* Updated the main proxy handler in `cloudflare/edge-proxy/src/index.ts` to enforce the new REST allowlist, returning 403 for any unlisted or disallowed requests. [[1]](diffhunk://#diff-e19dde9fbea814b69a129348405f4e363475ece8f8e0168ebab7b3791b59b17bR15-R16) [[2]](diffhunk://#diff-e19dde9fbea814b69a129348405f4e363475ece8f8e0168ebab7b3791b59b17bR113-R121)

**Testing and validation:**
* Added and expanded tests in `cloudflare/edge-proxy/src/routing_test.ts` to verify that only the intended tables/methods are allowed and that all other access is denied.
* Updated contract tests in `cloudflare/edge-proxy/src/index_contract_test.ts` to verify that direct writes to protected tables (e.g., `items`) are refused, and only allowed tables (e.g., `admin_audit_logs`) are writable. [[1]](diffhunk://#diff-74f36187de04d8828b6102524a7c56d0367db27ca4307095aa48b135325fa828L406-R406) [[2]](diffhunk://#diff-74f36187de04d8828b6102524a7c56d0367db27ca4307095aa48b135325fa828L416-R419) [[3]](diffhunk://#diff-74f36187de04d8828b6102524a7c56d0367db27ca4307095aa48b135325fa828R433-R448)

**Database migration and policy enforcement:**
* Added a static CI script (`scripts/check-privileged-rls-policies.mjs`) that parses database migrations to assert that privileged policies (RLS) remain least-privilege, that direct write paths are closed, and that super-admin policies require step-up and non-revoked sessions. This script fails CI if any invariant is violated, guarding against accidental privilege escalation in future migrations.

**Documentation and changelog:**
* Updated `CHANGELOG.md` to summarize the security improvements, including the REST allowlist, admin action confirmation, and expanded CI security checks.

**Security regression testing:**
* Added `adminReauth_test.ts` to the shared Supabase security regression tests to ensure admin reauthentication flows are covered in CI.

These changes collectively enforce strict least-privilege access at both the API and database levels, and add robust static and runtime test coverage to prevent regressions.