### PR TITLE
redesign cookie consent banner and nav dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Changes are dated based on the default timezone: America/Los_Angeles
 - Narrowed the data gateway to only the records the app actually uses.
 - Improved status page efficiency with short-term caching and request limits.
 - Expanded automated security checks in CI.
+- Refreshed the cookie preferences banner and top navigation menu with a cleaner look and smoother animations.
+- Cookie preference choices now stay consistent as you move between the marketing site and your workspace.
+- Minor accessibility improvements to cookie preference controls.
 
 ### 7/25/2026 Development Update
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -58,7 +58,6 @@
     <AuthenticatedNavigation
       :visible="showTopMenu"
       :show-notification-bell="showNotificationBell"
-      :is-outdated="isOutdated"
       :menu-open="menuOpen"
       :theme-label="themeLabel"
       :show-account-panel="showAccountPanel"

--- a/src/components/CookieConsentBanner.vue
+++ b/src/components/CookieConsentBanner.vue
@@ -254,10 +254,42 @@ const expanded = ref(false);
 
 @media (max-width: 480px) {
   .cookie-consent-banner {
-    left: 0.75rem;
-    right: 0.75rem;
-    bottom: 0.75rem;
+    left: 0.6rem;
+    right: 0.6rem;
+    bottom: 0.6rem;
     width: auto;
+    padding: 0.9rem;
+    border-radius: 14px;
+  }
+
+  .cookie-consent-title {
+    font-size: 0.88rem;
+    margin-bottom: 0.45rem;
+  }
+
+  .cookie-consent-body {
+    font-size: 0.8rem;
+    line-height: 1.45;
+    margin-bottom: 0.7rem;
+  }
+
+  .cookie-consent-legal {
+    font-size: 0.74rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .cookie-consent-actions .button-link {
+    min-height: 2.25rem;
+    font-size: 0.85rem;
+  }
+
+  .cookie-consent-prefs-toggle {
+    padding: 0.55rem 0 0.1rem;
+    font-size: 0.78rem;
+  }
+
+  .cookie-consent-option-name {
+    font-size: 0.8rem;
   }
 }
 </style>

--- a/src/components/CookieConsentBanner.vue
+++ b/src/components/CookieConsentBanner.vue
@@ -31,22 +31,22 @@
         <div class="cookie-consent-collapse" :class="{ 'is-open': expanded }">
           <div class="cookie-consent-panel">
             <div class="cookie-consent-panel-inner">
-              <div class="cookie-consent-option">
+              <label class="cookie-consent-option">
                 <span class="cookie-consent-option-name">Analytics</span>
-                <label class="cookie-consent-switch">
+                <span class="cookie-consent-switch">
                   <input v-model="analytics" type="checkbox" />
                   <span class="cookie-consent-switch-track"></span>
                   <span class="cookie-consent-switch-thumb"></span>
-                </label>
-              </div>
-              <div class="cookie-consent-option">
+                </span>
+              </label>
+              <label class="cookie-consent-option">
                 <span class="cookie-consent-option-name">Diagnostics</span>
-                <label class="cookie-consent-switch">
+                <span class="cookie-consent-switch">
                   <input v-model="diagnostics" type="checkbox" />
                   <span class="cookie-consent-switch-track"></span>
                   <span class="cookie-consent-switch-thumb"></span>
-                </label>
-              </div>
+                </span>
+              </label>
               <div class="cookie-consent-panel-actions">
                 <button
                   type="button"
@@ -188,6 +188,7 @@ const expanded = ref(false);
   justify-content: space-between;
   padding: 0.55rem 0;
   border-bottom: 1px solid var(--border);
+  cursor: pointer;
 }
 
 .cookie-consent-option:last-of-type {
@@ -211,6 +212,7 @@ const expanded = ref(false);
   height: 100%;
   margin: 0;
   position: absolute;
+  z-index: 1;
   cursor: pointer;
 }
 

--- a/src/components/CookieConsentBanner.vue
+++ b/src/components/CookieConsentBanner.vue
@@ -1,28 +1,64 @@
 <template>
   <Teleport to="body">
     <div class="cookie-consent-banner" role="dialog" aria-live="polite" aria-label="Cookie preferences">
-      <div class="cookie-consent-copy">
-        <p class="cookie-consent-eyebrow">Cookie Preferences</p>
-        <p>
-          ItemTraxx uses essential cookies for sign-in and security. With your consent, we may also use analytics and diagnostics
-          (for example PostHog and Sentry) to understand usage, performance, and reliability.
-        </p>
-        <div class="cookie-consent-options" aria-label="Optional cookie categories">
-          <label><input v-model="analytics" type="checkbox" /> Analytics</label>
-          <label><input v-model="diagnostics" type="checkbox" /> Diagnostics and error monitoring</label>
-        </div>
-        <p class="cookie-consent-legal">See the <RouterLink to="/privacy">Privacy Policy</RouterLink> and <RouterLink to="/cookies">Cookies Notice</RouterLink>.</p>
-      </div>
+      <h2 class="cookie-consent-title">Cookie preferences</h2>
+      <p class="cookie-consent-body">
+        Essential cookies keep sign-in and security working. Optional analytics and diagnostics help us fix issues
+        and improve the product.
+      </p>
+      <p class="cookie-consent-legal">
+        See <RouterLink to="/privacy">Privacy Policy</RouterLink> and <RouterLink to="/cookies">Cookies Notice</RouterLink>.
+      </p>
+
       <div class="cookie-consent-actions">
-        <button type="button" class="button-link cookie-consent-secondary" @click="$emit('essential-only')">
-          Essential only
-        </button>
-        <button type="button" class="button-link cookie-consent-secondary" @click="$emit('save-preferences', { analytics, diagnostics })">
-          Save choices
-        </button>
-        <button type="button" class="button-primary cookie-consent-primary" @click="$emit('accept-all')">
+        <button type="button" class="button-link cookie-consent-primary" @click="$emit('accept-all')">
           Accept all
         </button>
+        <div class="cookie-consent-row">
+          <button type="button" class="button-link" @click="$emit('essential-only')">Essential only</button>
+        </div>
+      </div>
+
+      <div class="cookie-consent-prefs">
+        <button
+          type="button"
+          class="cookie-consent-prefs-toggle"
+          :aria-expanded="expanded"
+          @click="expanded = !expanded"
+        >
+          Manage preferences <span class="cookie-consent-chev">▾</span>
+        </button>
+        <div class="cookie-consent-collapse" :class="{ 'is-open': expanded }">
+          <div class="cookie-consent-panel">
+            <div class="cookie-consent-panel-inner">
+              <div class="cookie-consent-option">
+                <span class="cookie-consent-option-name">Analytics</span>
+                <label class="cookie-consent-switch">
+                  <input v-model="analytics" type="checkbox" />
+                  <span class="cookie-consent-switch-track"></span>
+                  <span class="cookie-consent-switch-thumb"></span>
+                </label>
+              </div>
+              <div class="cookie-consent-option">
+                <span class="cookie-consent-option-name">Diagnostics</span>
+                <label class="cookie-consent-switch">
+                  <input v-model="diagnostics" type="checkbox" />
+                  <span class="cookie-consent-switch-track"></span>
+                  <span class="cookie-consent-switch-thumb"></span>
+                </label>
+              </div>
+              <div class="cookie-consent-panel-actions">
+                <button
+                  type="button"
+                  class="button-link cookie-consent-primary"
+                  @click="$emit('save-preferences', { analytics, diagnostics })"
+                >
+                  Save choices
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </Teleport>
@@ -40,115 +76,188 @@ defineEmits<{
 
 const analytics = ref(false);
 const diagnostics = ref(false);
+const expanded = ref(false);
 </script>
 
 <style scoped>
 .cookie-consent-banner {
   position: fixed;
-  left: 50%;
-  bottom: 1rem;
-  width: min(1280px, calc(100vw - 2rem));
+  right: 1.25rem;
+  bottom: 1.25rem;
+  width: min(360px, calc(100vw - 2rem));
   box-sizing: border-box;
-  transform: translateX(-50%);
   z-index: 1200;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1.5rem;
-  padding: 1.15rem 1.35rem;
-  border: 1px solid color-mix(in srgb, var(--border) 78%, var(--accent) 22%);
+  padding: 1.25rem;
+  border: 1px solid var(--border);
   border-radius: 18px;
-  background: color-mix(in srgb, var(--surface) 92%, rgba(5, 10, 18, 0.92) 8%);
+  background: var(--surface);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.32);
 }
 
-.cookie-consent-copy {
-  max-width: 58rem;
+.cookie-consent-title {
+  margin: 0 0 0.6rem;
+  font-size: 0.98rem;
+  font-weight: 600;
 }
 
-.cookie-consent-eyebrow {
-  margin: 0 0 0.35rem;
-  font-size: 0.78rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
+.cookie-consent-body {
+  margin: 0 0 0.9rem;
+  font-size: 0.87rem;
+  line-height: 1.55;
   color: var(--muted);
-}
-
-.cookie-consent-copy p:last-child {
-  margin: 0;
-  color: var(--text);
 }
 
 .cookie-consent-legal {
-  margin-top: 0.55rem;
-  font-size: 0.92rem;
+  margin: 0 0 1rem;
+  font-size: 0.8rem;
   color: var(--muted);
 }
 
-.cookie-consent-options {
+.cookie-consent-actions {
   display: flex;
-  gap: 0.75rem;
-  margin-top: 1rem;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
-.cookie-consent-options label {
-  display: inline-flex;
+.cookie-consent-actions .button-link {
+  width: 100%;
+}
+
+.cookie-consent-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.cookie-consent-row .button-link {
+  flex: 1;
+}
+
+.cookie-consent-prefs {
+  margin-top: 0.9rem;
+  border-top: 1px solid var(--border);
+}
+
+.cookie-consent-prefs-toggle {
+  width: 100%;
+  cursor: pointer;
+  padding: 0.7rem 0 0.1rem;
+  font-size: 0.82rem;
+  color: var(--muted);
+  display: flex;
   align-items: center;
-  gap: 0.6rem;
-  min-height: 2.75rem;
-  padding: 0.6rem 0.8rem;
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--surface) 88%, var(--accent) 12%);
+  justify-content: space-between;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  font-family: inherit;
+  outline: none;
 }
 
-.cookie-consent-options input {
+.cookie-consent-prefs-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.cookie-consent-chev {
+  transition: transform 0.25s ease;
+  display: inline-block;
+}
+
+.cookie-consent-prefs-toggle[aria-expanded="true"] .cookie-consent-chev {
+  transform: rotate(180deg);
+}
+
+.cookie-consent-collapse {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.28s ease;
+}
+
+.cookie-consent-collapse.is-open {
+  grid-template-rows: 1fr;
+}
+
+.cookie-consent-panel {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.cookie-consent-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.cookie-consent-option:last-of-type {
+  border-bottom: none;
+}
+
+.cookie-consent-option-name {
+  font-size: 0.85rem;
+}
+
+.cookie-consent-switch {
+  position: relative;
+  width: 2.4rem;
+  height: 1.4rem;
+  flex-shrink: 0;
+}
+
+.cookie-consent-switch input {
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  position: absolute;
+  cursor: pointer;
+}
+
+.cookie-consent-switch-track {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: var(--surface-3);
+  border: 1px solid var(--border);
+  transition: background 0.2s;
+}
+
+.cookie-consent-switch-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
   width: 1rem;
   height: 1rem;
-  margin: 0;
+  border-radius: 50%;
+  background: var(--muted);
+  transition: transform 0.2s, background 0.2s;
 }
 
-.cookie-consent-actions {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(9rem, 1fr));
-  gap: 0.75rem;
-  width: min(30rem, 34vw);
-  min-width: 21rem;
-  align-self: center;
+.cookie-consent-switch input:checked ~ .cookie-consent-switch-track {
+  background: var(--accent);
+  border-color: var(--accent);
 }
 
-.cookie-consent-secondary,
-.cookie-consent-primary {
-  justify-content: center;
-  white-space: nowrap;
+.cookie-consent-switch input:checked ~ .cookie-consent-switch-thumb {
+  transform: translateX(1rem);
+  background: var(--button-primary-text);
 }
 
-.cookie-consent-primary {
-  grid-column: 1 / -1;
-  grid-row: 1;
+.cookie-consent-panel-actions {
+  margin-top: 0.7rem;
 }
 
-@media (max-width: 760px) {
+.cookie-consent-panel-actions .button-link {
+  width: 100%;
+}
+
+@media (max-width: 480px) {
   .cookie-consent-banner {
     left: 0.75rem;
     right: 0.75rem;
     bottom: 0.75rem;
     width: auto;
-    flex-direction: column;
-    align-items: stretch;
-    transform: none;
-  }
-
-  .cookie-consent-actions {
-    display: flex;
-    min-width: 0;
-    flex-wrap: wrap;
-    justify-content: stretch;
-  }
-
-  .cookie-consent-actions > * {
-    flex: 1 1 auto;
-    justify-content: center;
   }
 }
 </style>

--- a/src/components/PublicFooter.vue
+++ b/src/components/PublicFooter.vue
@@ -199,6 +199,7 @@ onUnmounted(() => {
   color: inherit;
   font: inherit;
   cursor: pointer;
+  outline: none;
   transition: transform 160ms ease;
 }
 

--- a/src/components/app/AuthenticatedNavigation.vue
+++ b/src/components/app/AuthenticatedNavigation.vue
@@ -4,7 +4,6 @@
       <div v-if="showNotificationBell" class="menu-notification">
         <NotificationBell />
       </div>
-      <span v-if="isOutdated" class="menu-alert" aria-hidden="true">!</span>
       <button
         type="button"
         class="menu-button"
@@ -19,29 +18,47 @@
         </svg>
       </button>
     </div>
-    <div v-if="menuOpen" id="top-menu-dropdown" class="menu-dropdown" role="menu">
-      <button type="button" class="menu-item" role="menuitem" @click="emit('toggleTheme')">
-        {{ themeLabel }}
-      </button>
-      <RouterLink
-        v-if="showAccountPanel"
-        class="menu-item"
-        role="menuitem"
-        to="/account"
-        @click="emit('closeMenu')"
-      >
-        My Account
-      </RouterLink>
-      <button
-        v-if="showLogoutUserAction"
-        type="button"
-        class="menu-item danger"
-        role="menuitem"
-        @click="emit('logout')"
-      >
-        Log Out User
-      </button>
-    </div>
+    <Transition name="menu-dropdown">
+      <div v-if="menuOpen" id="top-menu-dropdown" class="menu-dropdown" role="menu">
+        <button type="button" class="menu-item" role="menuitem" @click="emit('toggleTheme')">
+          <svg class="menu-item-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="12" r="4" />
+            <path
+              d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"
+            />
+          </svg>
+          {{ themeLabel }}
+        </button>
+        <RouterLink
+          v-if="showAccountPanel"
+          class="menu-item"
+          role="menuitem"
+          to="/account"
+          @click="emit('closeMenu')"
+        >
+          <svg class="menu-item-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="8" r="4" />
+            <path d="M4 21c0-4.4 3.6-7 8-7s8 2.6 8 7" />
+          </svg>
+          My Account
+        </RouterLink>
+        <div v-if="showLogoutUserAction" class="menu-divider"></div>
+        <button
+          v-if="showLogoutUserAction"
+          type="button"
+          class="menu-item danger"
+          role="menuitem"
+          @click="emit('logout')"
+        >
+          <svg class="menu-item-icon" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+            <path d="M16 17l5-5-5-5" />
+            <path d="M21 12H9" />
+          </svg>
+          Sign out
+        </button>
+      </div>
+    </Transition>
   </div>
 </template>
 
@@ -57,7 +74,6 @@ const NotificationBell = defineAsyncComponent(async () => {
 defineProps<{
   visible: boolean;
   showNotificationBell: boolean;
-  isOutdated: boolean;
   menuOpen: boolean;
   themeLabel: string;
   showAccountPanel: boolean;

--- a/src/composables/useCookieConsentTelemetry.ts
+++ b/src/composables/useCookieConsentTelemetry.ts
@@ -50,20 +50,14 @@ export const useCookieConsentTelemetry = (auth: ConsentAuthState) => {
     savePreferences({ analytics: true, diagnostics: true });
   };
 
-  const handleStorage = (event: StorageEvent) => {
-    if (!event.key || event.key === "itemtraxx-cookie-consent") sync();
-  };
-
   watch(() => auth.role, syncConsentRecord);
 
   onMounted(() => {
     sync();
-    window.addEventListener("storage", handleStorage);
     window.addEventListener("itemtraxx:cookie-consent", sync);
   });
 
   onScopeDispose(() => {
-    window.removeEventListener("storage", handleStorage);
     window.removeEventListener("itemtraxx:cookie-consent", sync);
   });
 

--- a/src/services/cookieConsentService.ts
+++ b/src/services/cookieConsentService.ts
@@ -1,6 +1,7 @@
 const COOKIE_CONSENT_STORAGE_KEY = "itemtraxx-cookie-consent";
 const COOKIE_CONSENT_VERSION = 2;
 const COOKIE_CONSENT_SUBJECT_KEY = "itemtraxx-cookie-consent-subject";
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
 
 export type CookieConsentPreferences = {
   analytics: boolean;
@@ -13,18 +14,54 @@ export type CookieConsentState = {
   updatedAt: string;
 };
 
-const isBrowser = () => typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+const isBrowser = () => typeof window !== "undefined" && typeof document !== "undefined";
+
+const getCookieDomain = (): string | undefined => {
+  const hostname = window.location.hostname.toLowerCase();
+  if (hostname === "itemtraxx.com" || hostname.endsWith(".itemtraxx.com")) return ".itemtraxx.com";
+  return undefined;
+};
+
+const readCookie = (name: string): string | null => {
+  const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
+  return match ? decodeURIComponent(match[1]) : null;
+};
+
+const writeCookie = (name: string, value: string) => {
+  const domain = getCookieDomain();
+  const parts = [
+    `${name}=${encodeURIComponent(value)}`,
+    "Path=/",
+    `Max-Age=${COOKIE_MAX_AGE_SECONDS}`,
+    "SameSite=Lax",
+  ];
+  if (domain) parts.push(`Domain=${domain}`);
+  if (window.location.protocol === "https:") parts.push("Secure");
+  document.cookie = parts.join("; ");
+};
+
+const migrateFromLocalStorage = (key: string): string | null => {
+  if (typeof window.localStorage === "undefined") return null;
+  try {
+    const legacy = window.localStorage.getItem(key);
+    if (!legacy) return null;
+    window.localStorage.removeItem(key);
+    return legacy;
+  } catch {
+    return null;
+  }
+};
 
 export const readCookieConsent = (): CookieConsentState | null => {
   if (!isBrowser()) return null;
   try {
-    const raw = window.localStorage.getItem(COOKIE_CONSENT_STORAGE_KEY);
+    const raw = readCookie(COOKIE_CONSENT_STORAGE_KEY) ?? migrateFromLocalStorage(COOKIE_CONSENT_STORAGE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Partial<CookieConsentState>;
     if (parsed.version === 1 && (parsed as { choice?: unknown }).choice) {
       const choice = (parsed as { choice?: unknown }).choice;
       if ((choice === "essential" || choice === "all") && typeof parsed.updatedAt === "string") {
-        return {
+        const migrated: CookieConsentState = {
           version: COOKIE_CONSENT_VERSION,
           preferences: {
             analytics: choice === "all",
@@ -32,6 +69,8 @@ export const readCookieConsent = (): CookieConsentState | null => {
           },
           updatedAt: parsed.updatedAt,
         };
+        writeCookie(COOKIE_CONSENT_STORAGE_KEY, JSON.stringify(migrated));
+        return migrated;
       }
     }
     if (
@@ -42,11 +81,13 @@ export const readCookieConsent = (): CookieConsentState | null => {
     ) {
       return null;
     }
-    return {
+    const state: CookieConsentState = {
       version: COOKIE_CONSENT_VERSION,
       preferences: parsed.preferences,
       updatedAt: parsed.updatedAt,
     };
+    writeCookie(COOKIE_CONSENT_STORAGE_KEY, JSON.stringify(state));
+    return state;
   } catch {
     return null;
   }
@@ -60,19 +101,22 @@ export const writeCookieConsent = (preferences: CookieConsentPreferences) => {
     updatedAt: new Date().toISOString(),
   };
   try {
-    window.localStorage.setItem(COOKIE_CONSENT_STORAGE_KEY, JSON.stringify(next));
+    writeCookie(COOKIE_CONSENT_STORAGE_KEY, JSON.stringify(next));
     window.dispatchEvent(new CustomEvent("itemtraxx:cookie-consent", { detail: next }));
   } catch {
-    // Ignore localStorage failures.
+    // Ignore cookie write failures.
   }
 };
 
 export const getOrCreateCookieConsentSubject = () => {
   if (!isBrowser()) return "";
-  const existing = window.localStorage.getItem(COOKIE_CONSENT_SUBJECT_KEY);
-  if (existing) return existing;
+  const existing = readCookie(COOKIE_CONSENT_SUBJECT_KEY) ?? migrateFromLocalStorage(COOKIE_CONSENT_SUBJECT_KEY);
+  if (existing) {
+    writeCookie(COOKIE_CONSENT_SUBJECT_KEY, existing);
+    return existing;
+  }
   const subject = crypto.randomUUID();
-  window.localStorage.setItem(COOKIE_CONSENT_SUBJECT_KEY, subject);
+  writeCookie(COOKIE_CONSENT_SUBJECT_KEY, subject);
   return subject;
 };
 

--- a/src/styles/app-shell.css
+++ b/src/styles/app-shell.css
@@ -858,6 +858,16 @@ body.auth-route-active #app {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  border-radius: 10px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.menu-button:hover {
+  background: var(--surface-2);
 }
 
 .menu-button-wrap {
@@ -870,23 +880,6 @@ body.auth-route-active #app {
 .menu-notification {
   display: inline-flex;
   align-items: center;
-}
-
-.menu-alert {
-  position: absolute;
-  right: 44px;
-  top: -4px;
-  width: 16px;
-  height: 16px;
-  border-radius: 999px;
-  background: #f5b700;
-  color: #000000;
-  font-size: 0.7rem;
-  font-weight: 800;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid rgba(0, 0, 0, 0.3);
 }
 
 .menu-icon {
@@ -909,18 +902,37 @@ body.auth-route-active #app {
   backdrop-filter: none;
   min-width: 220px;
   padding: 0.4rem;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.28);
+}
+
+.menu-dropdown-enter-active,
+.menu-dropdown-leave-active {
+  transition: clip-path 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.menu-dropdown-enter-from,
+.menu-dropdown-leave-to {
+  clip-path: inset(0 0 100% 0 round 16px);
+}
+
+.menu-dropdown-enter-to,
+.menu-dropdown-leave-from {
+  clip-path: inset(0 0 0% 0 round 16px);
 }
 
 .menu-item {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
   width: 100%;
   text-align: left;
-  padding: 0.5rem 0.6rem;
-  border-radius: 8px;
+  padding: 0.55rem 0.65rem;
+  border-radius: 10px;
   border: none;
   background: transparent;
   color: inherit;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
+  cursor: pointer;
 }
 
 .menu-item:hover {
@@ -928,7 +940,24 @@ body.auth-route-active #app {
 }
 
 .menu-item.danger {
-  color: #d83a3a;
+  color: var(--danger);
+}
+
+.menu-item-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.menu-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 0.35rem 0.2rem;
 }
 
 .status-warning {

--- a/tests/e2e/helpers/testHarness.ts
+++ b/tests/e2e/helpers/testHarness.ts
@@ -1,5 +1,17 @@
 import type { BrowserContext, Page } from "@playwright/test";
 
+export const readCookieConsentPreferences = (page: Page) =>
+  page.evaluate(() => {
+    const match = document.cookie.match(/(?:^|; )itemtraxx-cookie-consent=([^;]*)/);
+    if (!match) return undefined;
+    return JSON.parse(decodeURIComponent(match[1]))?.preferences;
+  });
+
+export const clearCookieConsentCookie = (page: Page) =>
+  page.evaluate(() => {
+    document.cookie = "itemtraxx-cookie-consent=; Max-Age=0; Path=/; SameSite=Lax";
+  });
+
 export const mockSystemStatus = async (page: Page) => {
   await page.route(/\/functions(?:\/v1)?\/system-status(?:\?.*)?$/, async (route) => {
     await route.fulfill({

--- a/tests/e2e/privacy-compliance.spec.ts
+++ b/tests/e2e/privacy-compliance.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { mockSystemStatus, mockUnauthenticatedSession } from "./helpers/testHarness";
+import {
+  clearCookieConsentCookie,
+  mockSystemStatus,
+  mockUnauthenticatedSession,
+  readCookieConsentPreferences,
+} from "./helpers/testHarness";
 
 test.describe("Privacy and legal controls", () => {
   test.beforeEach(async ({ page }) => {
@@ -10,16 +15,11 @@ test.describe("Privacy and legal controls", () => {
   test("stores independent analytics and diagnostics preferences", async ({ page }) => {
     await page.goto("/");
 
-    await page.getByLabel("Optional cookie categories").getByLabel("Analytics").check();
+    await page.getByRole("button", { name: "Manage preferences" }).click();
+    await page.getByRole("checkbox", { name: "Analytics" }).check();
     await page.getByRole("button", { name: "Save choices" }).click();
 
-    const stored = await page.evaluate(() =>
-      JSON.parse(localStorage.getItem("itemtraxx-cookie-consent") ?? "null")
-    );
-    expect(stored).toMatchObject({
-      version: 2,
-      preferences: { analytics: true, diagnostics: false },
-    });
+    await expect.poll(() => readCookieConsentPreferences(page)).toEqual({ analytics: true, diagnostics: false });
     await page.reload();
     await expect(page.getByRole("dialog", { name: "Cookie preferences" })).toHaveCount(0);
   });
@@ -27,16 +27,12 @@ test.describe("Privacy and legal controls", () => {
   test("stores essential-only and accept-all choices accurately", async ({ page }) => {
     await page.goto("/");
     await page.getByRole("button", { name: "Essential only" }).click();
-    await expect.poll(() => page.evaluate(() =>
-      JSON.parse(localStorage.getItem("itemtraxx-cookie-consent") ?? "null")?.preferences
-    )).toEqual({ analytics: false, diagnostics: false });
+    await expect.poll(() => readCookieConsentPreferences(page)).toEqual({ analytics: false, diagnostics: false });
 
-    await page.evaluate(() => localStorage.removeItem("itemtraxx-cookie-consent"));
+    await clearCookieConsentCookie(page);
     await page.reload();
     await page.getByRole("button", { name: "Accept all" }).click();
-    await expect.poll(() => page.evaluate(() =>
-      JSON.parse(localStorage.getItem("itemtraxx-cookie-consent") ?? "null")?.preferences
-    )).toEqual({ analytics: true, diagnostics: true });
+    await expect.poll(() => readCookieConsentPreferences(page)).toEqual({ analytics: true, diagnostics: true });
   });
 
   test("does not load PostHog or retain its persistence before consent", async ({ page, context }) => {

--- a/tests/e2e/public-and-legal.spec.ts
+++ b/tests/e2e/public-and-legal.spec.ts
@@ -1,6 +1,12 @@
 import { expect, test } from "@playwright/test";
 import { readFile } from "node:fs/promises";
-import { mockSystemStatus, mockUnauthenticatedSession, navigateApp } from "./helpers/testHarness";
+import {
+  clearCookieConsentCookie,
+  mockSystemStatus,
+  mockUnauthenticatedSession,
+  navigateApp,
+  readCookieConsentPreferences,
+} from "./helpers/testHarness";
 
 const forbiddenSdkResponse = (url: string) => {
   const filename = new URL(url).pathname.split("/").pop()?.toLowerCase() ?? "";
@@ -52,6 +58,7 @@ test.describe("Public surfaces", () => {
         { level: 3, name: "Built for teams, organizations, and individual users." },
         { level: 2, name: "Answers to the common stuff." },
         { level: 2, name: "Get started with ItemTraxx and advance your inventory management." },
+        { level: 2, name: "Cookie preferences" },
       ]);
 
       const primaryNav = page.getByRole("navigation", { name: "Primary" });
@@ -635,11 +642,7 @@ test.describe("Public surfaces", () => {
     await page.goto("/login");
 
     await page.getByRole("button", { name: "Accept all" }).click();
-    await expect.poll(() =>
-      page.evaluate(() =>
-        JSON.parse(localStorage.getItem("itemtraxx-cookie-consent") ?? "null")?.preferences,
-      ),
-    ).toEqual({ analytics: true, diagnostics: true });
+    await expect.poll(() => readCookieConsentPreferences(page)).toEqual({ analytics: true, diagnostics: true });
 
     await page.getByRole("button", { name: "Open menu" }).click();
     await page.getByRole("menuitem", { name: "Dark Mode" }).click();
@@ -651,35 +654,24 @@ test.describe("Public surfaces", () => {
     await expect(page.getByRole("button", { name: "Accept all" })).toHaveCount(0);
   });
 
-  test("essential and custom consent synchronize through storage and custom events", async ({ page }) => {
+  test("essential and custom consent synchronize through custom events", async ({ page }) => {
     await page.goto("/login");
     const consentDialog = page.getByRole("dialog", { name: "Cookie preferences" });
 
     await consentDialog.getByRole("button", { name: "Essential only" }).click();
-    await expect.poll(() =>
-      page.evaluate(() =>
-        JSON.parse(localStorage.getItem("itemtraxx-cookie-consent") ?? "null")?.preferences,
-      ),
-    ).toEqual({ analytics: false, diagnostics: false });
+    await expect.poll(() => readCookieConsentPreferences(page)).toEqual({ analytics: false, diagnostics: false });
 
-    await page.evaluate(() => {
-      localStorage.removeItem("itemtraxx-cookie-consent");
-      window.dispatchEvent(new StorageEvent("storage", { key: "itemtraxx-cookie-consent" }));
-    });
+    await clearCookieConsentCookie(page);
+    await page.evaluate(() => window.dispatchEvent(new CustomEvent("itemtraxx:cookie-consent")));
     await expect(consentDialog).toBeVisible();
 
+    await consentDialog.getByRole("button", { name: "Manage preferences" }).click();
     await consentDialog.getByRole("checkbox", { name: "Analytics" }).check();
     await consentDialog.getByRole("button", { name: "Save choices" }).click();
-    await expect.poll(() =>
-      page.evaluate(() =>
-        JSON.parse(localStorage.getItem("itemtraxx-cookie-consent") ?? "null")?.preferences,
-      ),
-    ).toEqual({ analytics: true, diagnostics: false });
+    await expect.poll(() => readCookieConsentPreferences(page)).toEqual({ analytics: true, diagnostics: false });
 
-    await page.evaluate(() => {
-      localStorage.removeItem("itemtraxx-cookie-consent");
-      window.dispatchEvent(new CustomEvent("itemtraxx:cookie-consent"));
-    });
+    await clearCookieConsentCookie(page);
+    await page.evaluate(() => window.dispatchEvent(new CustomEvent("itemtraxx:cookie-consent")));
     await expect(consentDialog).toBeVisible();
   });
 

--- a/tests/e2e/super-flows-and-exports.spec.ts
+++ b/tests/e2e/super-flows-and-exports.spec.ts
@@ -97,7 +97,7 @@ test.describe("Super admin flows and export actions", () => {
     await navigateApp(page, "/super-admin");
 
     await page.getByRole("button", { name: "Open menu" }).click();
-    await expect(page.getByRole("menuitem", { name: "Log Out User" })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Sign out" })).toBeVisible();
   });
 
   test("control-center actions preserve their exact request envelopes", async ({ page }) => {


### PR DESCRIPTION
Cookie banner moves to a corner card with an expandable manage-preferences panel. Nav dropdown gets a ghost-style trigger, icon rows, a grow-down open/close transition, and drops the outdated-version badge (still surfaced via the separate version overlay). Fixed a default focus-ring overlap on the footer theme toggle along the way.