### PR TITLE
Bump posthog-js to version 1.407.3 and update changelog

### DIFF
--- a/.github/workflows/strix-security.yml
+++ b/.github/workflows/strix-security.yml
@@ -38,9 +38,13 @@ jobs:
 
       - name: Install Strix
         env:
-          STRIX_VERSION: 1.1.0
-          # SHA-256 published for strix-1.1.0-linux-x86_64.tar.gz.
-          STRIX_SHA256: 7e8be841b9195a16e038eaa43e69452dc616fb19ca6979afbcaa9d842960e7e7
+          # Pinned below v1.1.0: Caido was introduced in v1.1.0 and its sandbox
+          # bootstrap race ("Could not acquire a connection to the database")
+          # 500s all outbound sandbox traffic, including the LLM warm-up call.
+          # See https://github.com/usestrix/strix/issues/830.
+          STRIX_VERSION: 1.0.4
+          # SHA-256 published for strix-1.0.4-linux-x86_64.tar.gz.
+          STRIX_SHA256: cdde264d2163684ca07168252130df154842d5fb22cd8e00bc6d19f1c74d5dae
         run: |
           strix_dir="$RUNNER_TEMP/strix-${STRIX_VERSION}"
           strix_archive="$strix_dir/strix.tar.gz"

--- a/.github/workflows/strix-security.yml
+++ b/.github/workflows/strix-security.yml
@@ -53,6 +53,25 @@ jobs:
           install -m 0755 "$strix_dir/strix-${STRIX_VERSION}-linux-x86_64" "$strix_dir/bin/strix"
           echo "$strix_dir/bin" >> "$GITHUB_PATH"
 
+      - name: Debug - NIM reachability from sandbox container
+        env:
+          LLM_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+        run: |
+          docker pull ghcr.io/usestrix/strix-sandbox:1.0.0
+          docker run --rm -e LLM_API_KEY \
+            ghcr.io/usestrix/strix-sandbox:1.0.0 \
+            sh -c '
+              set -x
+              curl -sS -o /dev/null -w "models_endpoint http_code=%{http_code} time=%{time_total}s\n" --max-time 20 \
+                https://integrate.api.nvidia.com/v1/models || echo "models endpoint curl failed rc=$?"
+              curl -sS -o /tmp/chat_resp.json -w "chat_completions http_code=%{http_code} time=%{time_total}s\n" --max-time 60 \
+                -H "Authorization: Bearer $LLM_API_KEY" \
+                -H "Content-Type: application/json" \
+                -d "{\"model\":\"deepseek-ai/deepseek-v4-flash\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":8}" \
+                https://integrate.api.nvidia.com/v1/chat/completions || echo "chat completions curl failed rc=$?"
+              cat /tmp/chat_resp.json || true
+            '
+
       - name: Run Strix security scan
         id: strix-scan
         env:

--- a/.github/workflows/strix-security.yml
+++ b/.github/workflows/strix-security.yml
@@ -62,6 +62,8 @@ jobs:
             ghcr.io/usestrix/strix-sandbox:1.0.0 \
             sh -c '
               set -x
+              curl -sS --max-time 10 https://ifconfig.me || echo "ifconfig.me curl failed rc=$?"
+              echo
               curl -sS -o /dev/null -w "models_endpoint http_code=%{http_code} time=%{time_total}s\n" --max-time 20 \
                 https://integrate.api.nvidia.com/v1/models || echo "models endpoint curl failed rc=$?"
               curl -sS -o /tmp/chat_resp.json -w "chat_completions http_code=%{http_code} time=%{time_total}s\n" --max-time 60 \

--- a/.github/workflows/strix-security.yml
+++ b/.github/workflows/strix-security.yml
@@ -21,7 +21,14 @@ jobs:
 
   strix-security-scan:
     needs: kill-switch-preflight
-    if: ${{ (github.event_name == 'workflow_dispatch' || (github.event.pull_request.base.ref == 'preview' && github.event.pull_request.head.ref == 'staging')) && needs.kill-switch-preflight.outputs.active != 'true' }}
+    # Disabled: Strix's sandbox image has a Caido bootstrap race
+    # ("Could not acquire a connection to the database") that 500s all
+    # outbound sandbox traffic, including the LLM warm-up call. Confirmed
+    # this is independent of the Strix CLI version (reproduces on both
+    # v1.1.0 and v1.0.4), so it lives in the shared sandbox image, not
+    # something we can pin around. Re-enable once fixed upstream:
+    # https://github.com/usestrix/strix/issues/830
+    if: false && ((github.event_name == 'workflow_dispatch' || (github.event.pull_request.base.ref == 'preview' && github.event.pull_request.head.ref == 'staging')) && needs.kill-switch-preflight.outputs.active != 'true')
     permissions:
       contents: read
       pull-requests: write
@@ -38,13 +45,9 @@ jobs:
 
       - name: Install Strix
         env:
-          # Pinned below v1.1.0: Caido was introduced in v1.1.0 and its sandbox
-          # bootstrap race ("Could not acquire a connection to the database")
-          # 500s all outbound sandbox traffic, including the LLM warm-up call.
-          # See https://github.com/usestrix/strix/issues/830.
-          STRIX_VERSION: 1.0.4
-          # SHA-256 published for strix-1.0.4-linux-x86_64.tar.gz.
-          STRIX_SHA256: cdde264d2163684ca07168252130df154842d5fb22cd8e00bc6d19f1c74d5dae
+          STRIX_VERSION: 1.1.0
+          # SHA-256 published for strix-1.1.0-linux-x86_64.tar.gz.
+          STRIX_SHA256: 7e8be841b9195a16e038eaa43e69452dc616fb19ca6979afbcaa9d842960e7e7
         run: |
           strix_dir="$RUNNER_TEMP/strix-${STRIX_VERSION}"
           strix_archive="$strix_dir/strix.tar.gz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changes are dated based on the default timezone: America/Los_Angeles
 
 ---
 
+### 7/27/2026 Development Update
+
+- Completed routine dependency maintenance.
+
 ### 7/26/2026 Development Update
 
 - Strengthened database permissions so records can only be changed through verified server paths.

--- a/deno.lock
+++ b/deno.lock
@@ -14,7 +14,7 @@
     "npm:jsbarcode@^3.12.3": "3.12.3",
     "npm:jspdf-autotable@^5.0.8": "5.0.8_jspdf@4.2.1",
     "npm:jspdf@^4.2.1": "4.2.1",
-    "npm:posthog-js@^1.407.2": "1.407.2",
+    "npm:posthog-js@^1.407.3": "1.407.3",
     "npm:supabase@2.109.1": "2.109.1",
     "npm:typescript@~6.0.3": "6.0.3",
     "npm:vite@^8.1.5": "8.1.5_@types+node@26.1.1",
@@ -587,8 +587,8 @@
     "@poppinss/exception@1.2.3": {
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="
     },
-    "@posthog/browser-common@0.2.1": {
-      "integrity": "sha512-FTVPsRw6GBKWvFwN26TNIQNNYPR9FsUj+B+CKhk/ht63IRzn4yYFtFOjcmW+bfXvNHuRADs6APbZ6Haz1kpoAw==",
+    "@posthog/browser-common@0.2.2": {
+      "integrity": "sha512-4NHumu2lx7pMeucDLfXnDmeP5CV2oVWY8jBpXBwBUjoYwkQxB7Z3A6q9oDydw+/iSAGl6MaPqW9gsnRK8AvqLA==",
       "dependencies": [
         "@posthog/core",
         "@posthog/types"
@@ -1797,8 +1797,8 @@
         "source-map-js"
       ]
     },
-    "posthog-js@1.407.2": {
-      "integrity": "sha512-5deTvXopn+NJWEmCUw8Ix/ms3cv2+60WJ73Vgbvu2wSkZY/FIj2uqAgCnq7IewGpGC+tH7CAbPYFzH6hw8eW1w==",
+    "posthog-js@1.407.3": {
+      "integrity": "sha512-b9Kc7HVN6nh+xsh1JrcLYHv9bbYLwYUM9belJtNVUFZSJWWfFcZRJJP6L+KeanAeu2VxSFSpioVA39pjjolv4A==",
       "dependencies": [
         "@posthog/browser-common",
         "@posthog/core",
@@ -2459,7 +2459,7 @@
         "npm:jsbarcode@^3.12.3",
         "npm:jspdf-autotable@^5.0.8",
         "npm:jspdf@^4.2.1",
-        "npm:posthog-js@^1.407.2",
+        "npm:posthog-js@^1.407.3",
         "npm:supabase@2.109.1",
         "npm:typescript@~6.0.3",
         "npm:vite@^8.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "jsbarcode": "^3.12.3",
         "jspdf": "^4.2.1",
         "jspdf-autotable": "^5.0.8",
-        "posthog-js": "^1.407.2",
+        "posthog-js": "^1.407.3",
         "vue": "^3.5.40",
         "vue-router": "^4.6.4",
         "zod": "^4.4.3"
@@ -1596,9 +1596,9 @@
       "license": "MIT"
     },
     "node_modules/@posthog/browser-common": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.2.1.tgz",
-      "integrity": "sha512-FTVPsRw6GBKWvFwN26TNIQNNYPR9FsUj+B+CKhk/ht63IRzn4yYFtFOjcmW+bfXvNHuRADs6APbZ6Haz1kpoAw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.2.2.tgz",
+      "integrity": "sha512-4NHumu2lx7pMeucDLfXnDmeP5CV2oVWY8jBpXBwBUjoYwkQxB7Z3A6q9oDydw+/iSAGl6MaPqW9gsnRK8AvqLA==",
       "license": "MIT",
       "dependencies": {
         "@posthog/core": "^1.45.1",
@@ -3971,12 +3971,12 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "1.407.2",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.407.2.tgz",
-      "integrity": "sha512-5deTvXopn+NJWEmCUw8Ix/ms3cv2+60WJ73Vgbvu2wSkZY/FIj2uqAgCnq7IewGpGC+tH7CAbPYFzH6hw8eW1w==",
+      "version": "1.407.3",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.407.3.tgz",
+      "integrity": "sha512-b9Kc7HVN6nh+xsh1JrcLYHv9bbYLwYUM9belJtNVUFZSJWWfFcZRJJP6L+KeanAeu2VxSFSpioVA39pjjolv4A==",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
-        "@posthog/browser-common": "^0.2.0",
+        "@posthog/browser-common": "^0.2.2",
         "@posthog/core": "^1.45.1",
         "@posthog/types": "^1.398.0",
         "core-js": "^3.49.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jsbarcode": "^3.12.3",
     "jspdf": "^4.2.1",
     "jspdf-autotable": "^5.0.8",
-    "posthog-js": "^1.407.2",
+    "posthog-js": "^1.407.3",
     "vue": "^3.5.40",
     "vue-router": "^4.6.4",
     "zod": "^4.4.3"

--- a/scripts/prepare-strix-pr-summary.py
+++ b/scripts/prepare-strix-pr-summary.py
@@ -40,24 +40,37 @@ def finding_summary(result: object) -> tuple[str, str, str]:
     return (severity, rule_id, location)
 
 
-def collect_findings(findings_root: Path) -> list[tuple[str, str, str]]:
+def collect_findings(findings_root: Path) -> tuple[list[tuple[str, str, str]], bool]:
     findings = []
+    sarif_found = False
     for path in findings_root.glob("**/findings.sarif"):
+        sarif_found = True
         with path.open(encoding="utf-8") as report_file:
             report = json.load(report_file)
         for sarif_run in report.get("runs", []):
             if isinstance(sarif_run, dict):
                 for result in sarif_run.get("results", []):
                     findings.append(finding_summary(result))
-    return findings
+    return findings, sarif_found
 
 
-def build_comment(exit_code: str, findings: list[tuple[str, str, str]]) -> str:
-    if exit_code == "0" and not findings:
+def build_comment(
+    exit_code: str,
+    findings: list[tuple[str, str, str]],
+    sarif_found: bool,
+) -> str:
+    if exit_code == "0" and not findings and sarif_found:
         lines = [
             MARKER,
             "## Strix security scan",
             "Strix completed the security scan and found no exploitable vulnerabilities.",
+        ]
+    elif exit_code == "0" and not findings and not sarif_found:
+        lines = [
+            MARKER,
+            "## Strix security scan",
+            "Strix completed, but no SARIF report was found, so results can't be summarized here. "
+            "Review the Strix results artifact on this workflow run for the actual output.",
         ]
     elif findings:
         visible_findings = findings[:MAX_FINDINGS_IN_COMMENT]
@@ -88,7 +101,8 @@ def main() -> None:
     parser.add_argument("--output", type=Path)
     args = parser.parse_args()
 
-    comment = build_comment(args.exit_code, collect_findings(args.findings_root))
+    findings, sarif_found = collect_findings(args.findings_root)
+    comment = build_comment(args.exit_code, findings, sarif_found)
     output = args.output or Path(os.environ.get("RUNNER_TEMP", ".")) / "strix-pr-comment.md"
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(comment, encoding="utf-8")

--- a/src/services/appErrorRecovery.ts
+++ b/src/services/appErrorRecovery.ts
@@ -14,7 +14,7 @@ let recoveryInstalled = false;
 
 export const isRecoverableChunkLoadError = (error: unknown) => {
   const message = error instanceof Error ? error.message : String(error ?? "");
-  return /failed to fetch dynamically imported module|error loading dynamically imported module|importing a module script failed/i
+  return /failed to fetch dynamically imported module|error loading dynamically imported module|importing a module script failed|couldn't resolve component/i
     .test(message);
 };
 


### PR DESCRIPTION
This pull request includes several updates related to Strix security scanning, dependency maintenance, and error handling improvements. The main changes involve disabling the Strix security scan in CI due to an upstream sandbox issue, enhancing the Strix PR summary script to better handle missing SARIF reports, updating a dependency, and improving error detection for dynamic imports.

**Strix Security Scan Workflow Updates:**

* The Strix security scan job in `.github/workflows/strix-security.yml` is now disabled (`if: false`) due to a known issue with the Strix sandbox image causing database connection failures, with a note to re-enable once the upstream issue is fixed.
* Added a debug step to the Strix workflow to check network reachability and LLM API access from the sandbox container, aiding in troubleshooting.

**Strix PR Summary Script Improvements:**

* The `scripts/prepare-strix-pr-summary.py` script now detects if no SARIF report is present and updates the PR comment accordingly, clarifying when results can't be summarized due to missing reports. [[1]](diffhunk://#diff-5415b292343145ed5ebdfdc5e4cb1fc083caaf51aa330e1ddc3c1440bea8b851L43-R74) [[2]](diffhunk://#diff-5415b292343145ed5ebdfdc5e4cb1fc083caaf51aa330e1ddc3c1440bea8b851L91-R105)

**Dependency Maintenance:**

* Updated the `posthog-js` dependency from version `1.407.2` to `1.407.3` in `package.json`.
* Noted routine dependency maintenance in the changelog.

**Error Handling Enhancements:**

* Improved the `isRecoverableChunkLoadError` function to recognize an additional error pattern (`couldn't resolve component`) for better detection of recoverable dynamic import errors.