### PR TITLE
fix: pin ip-address override to 10.3.1

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,27 +1,27 @@
 {
   "version": "5",
   "specifiers": {
-    "npm:@cloudflare/vite-plugin@^1.47.0": "1.47.0_vite@8.1.5__@types+node@26.1.1_wrangler@4.114.0",
+    "npm:@cloudflare/vite-plugin@^1.48.0": "1.48.0_vite@8.1.5__@types+node@26.1.2_wrangler@4.115.0_@types+node@26.1.2",
     "npm:@cyclonedx/cyclonedx-npm@6.0.0": "6.0.0",
     "npm:@playwright/test@^1.62.0": "1.62.0",
     "npm:@sentry/vue@^10.68.0": "10.68.0_vue@3.5.40__typescript@6.0.3",
-    "npm:@supabase/supabase-js@^2.110.8": "2.110.8",
-    "npm:@types/node@^26.1.1": "26.1.1",
+    "npm:@supabase/supabase-js@^2.111.0": "2.111.0",
+    "npm:@types/node@^26.1.2": "26.1.2",
     "npm:@vercel/analytics@^2.0.1": "2.0.1_vue@3.5.40__typescript@6.0.3_vue-router@4.6.4__vue@3.5.40___typescript@6.0.3__typescript@6.0.3_typescript@6.0.3",
     "npm:@vercel/speed-insights@2": "2.0.0_vue@3.5.40__typescript@6.0.3_vue-router@4.6.4__vue@3.5.40___typescript@6.0.3__typescript@6.0.3_typescript@6.0.3",
-    "npm:@vitejs/plugin-vue@^6.0.8": "6.0.8_vite@8.1.5__@types+node@26.1.1_vue@3.5.40__typescript@6.0.3_@types+node@26.1.1_typescript@6.0.3",
+    "npm:@vitejs/plugin-vue@^6.0.8": "6.0.8_vite@8.1.5__@types+node@26.1.2_vue@3.5.40__typescript@6.0.3_@types+node@26.1.2",
     "npm:@vue/tsconfig@~0.9.1": "0.9.1_typescript@6.0.3_vue@3.5.40__typescript@6.0.3",
     "npm:jsbarcode@^3.12.3": "3.12.3",
     "npm:jspdf-autotable@^5.0.8": "5.0.8_jspdf@4.2.1",
     "npm:jspdf@^4.2.1": "4.2.1",
-    "npm:posthog-js@^1.407.2": "1.407.2",
+    "npm:posthog-js@^1.407.5": "1.407.5",
     "npm:supabase@2.109.1": "2.109.1",
     "npm:typescript@~6.0.3": "6.0.3",
-    "npm:vite@^8.1.5": "8.1.5_@types+node@26.1.1",
+    "npm:vite@^8.1.5": "8.1.5_@types+node@26.1.2",
     "npm:vue-router@^4.6.4": "4.6.4_vue@3.5.40__typescript@6.0.3_typescript@6.0.3",
     "npm:vue-tsc@^3.3.8": "3.3.8_typescript@6.0.3",
     "npm:vue@^3.5.40": "3.5.40_typescript@6.0.3",
-    "npm:wrangler@^4.114.0": "4.114.0",
+    "npm:wrangler@^4.115.0": "4.115.0",
     "npm:zod@^4.4.3": "4.4.3"
   },
   "npm": {
@@ -61,8 +61,8 @@
         "workerd"
       ]
     },
-    "@cloudflare/vite-plugin@1.47.0_vite@8.1.5__@types+node@26.1.1_wrangler@4.114.0": {
-      "integrity": "sha512-WyGNYtJ2nzcJXtlwCHTO5S5+flFaYhfH5WfFfx6IpGf2Y/oNwyizEW9mNSImpg65PWmDs1715Pk/vGSKKtYJ1w==",
+    "@cloudflare/vite-plugin@1.48.0_vite@8.1.5__@types+node@26.1.2_wrangler@4.115.0_@types+node@26.1.2": {
+      "integrity": "sha512-Qt+lhot9ws3K4qOZYRuvsU03QsdLjQ63dgVrQo47kTL+SJmHScaQYG40mnJAKYL84mVT/ai7eFQORUxM6vMrWQ==",
       "dependencies": [
         "@cloudflare/unenv-preset",
         "miniflare",
@@ -587,8 +587,8 @@
     "@poppinss/exception@1.2.3": {
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="
     },
-    "@posthog/browser-common@0.2.1": {
-      "integrity": "sha512-FTVPsRw6GBKWvFwN26TNIQNNYPR9FsUj+B+CKhk/ht63IRzn4yYFtFOjcmW+bfXvNHuRADs6APbZ6Haz1kpoAw==",
+    "@posthog/browser-common@0.2.4": {
+      "integrity": "sha512-/xI4sIVNiZMJButhNdQFdCHtOcB6v8xM8vtJKznqqB7SMbpYwUNok68iPxGNZHPDwUYM6GAqM/AbMiS80UNyMw==",
       "dependencies": [
         "@posthog/core",
         "@posthog/types"
@@ -747,8 +747,8 @@
     "@speed-highlight/core@1.2.17": {
       "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="
     },
-    "@supabase/auth-js@2.110.8": {
-      "integrity": "sha512-TQ5neTUDX2C2WmyYa03yGhLMkhdE/SkHXtK8/qxO/APUy3rsymsJCBP48p4jcN6iO2G0ow6RRexQd2mX+dSyJg==",
+    "@supabase/auth-js@2.111.0": {
+      "integrity": "sha512-hbRLgyQZEX0SDyF4LYXpv94qOIQyFATfpT5SIs2V0SisHnisVRkYgiPQWzv80l4S2mO3qof78rmoH9j5zoFsYQ==",
       "dependencies": [
         "tslib"
       ]
@@ -793,8 +793,8 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@supabase/functions-js@2.110.8": {
-      "integrity": "sha512-5yB9TLYzvv2oSQxwb0gamEvIAsuH66pVt7AM/pz03S7wN6ehD34GNgbShrccetqPedXQSz7e/1hAJ9NeEhoZVg==",
+    "@supabase/functions-js@2.111.0": {
+      "integrity": "sha512-RW/OCsd6MO592zU8ifzP8/f8XzxxIdpb+Up5XaOtE26Fw+3zTp475WX7+GuuktiD1WF8pFUDe6khUPbMp77RCw==",
       "dependencies": [
         "tslib"
       ]
@@ -802,28 +802,28 @@
     "@supabase/phoenix@0.4.5": {
       "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="
     },
-    "@supabase/postgrest-js@2.110.8": {
-      "integrity": "sha512-QeRROxl1PpOZw5Jzi7BwdN9icsycMrLlCCvsjS0hYLW+nZoaT46zdagz/glJirj8jHF4jSd5Jyipuae2cBClCw==",
+    "@supabase/postgrest-js@2.111.0": {
+      "integrity": "sha512-pcqeDsnWP0lx9GawduYxNZJHeuTm53O7L0SC8RF8tniV3GWIPY6me6OTdnwzdwNUmNy1dzUVtSyIfE6+OflzPQ==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@supabase/realtime-js@2.110.8": {
-      "integrity": "sha512-mwX7ituX6O31fLf+0g65rpLlNxqgnMaPltPsQwzox6jfmbfVl3tCxXrfr3HEsQcCRjpjuJG1+A0vFzP1yVjKHA==",
+    "@supabase/realtime-js@2.111.0": {
+      "integrity": "sha512-6oRf/vZyRwg8f8GbFSJkrD2w4HAu/yTvyMViHXHS+H5hNJzdXCrUR7cP5oW7daT3YlRnzRPY9LcGSJKZAmfMSg==",
       "dependencies": [
         "@supabase/phoenix",
         "tslib"
       ]
     },
-    "@supabase/storage-js@2.110.8": {
-      "integrity": "sha512-CcfhkZFBLxsthgUabZKxwfsoXdrikIGsL3LsGoV3FZTqCMx/s1y49taT4jT/oya5+1IuB0sFFHw6pF0o0iJniQ==",
+    "@supabase/storage-js@2.111.0": {
+      "integrity": "sha512-UEViNmTzVOxE8dqUA81wls+n9xgmlvSFfhfwo6QxrO4kQOytCYyw3ciYFoi4XoD4Jl95NJ3jnndHN5iIudWzqw==",
       "dependencies": [
         "iceberg-js",
         "tslib"
       ]
     },
-    "@supabase/supabase-js@2.110.8": {
-      "integrity": "sha512-E5qzoe74zhJRv4wRcbO9eMYzeQDb/+h6c603pL8shcxLGBjTKsIF7XXj05IcNj23TLDgJN1WkMw7mwAPyu5dZg==",
+    "@supabase/supabase-js@2.111.0": {
+      "integrity": "sha512-9q0/AULthQnWeiDh1vGyjoJZbSY04bu6qHcWit70pqEYn5Kv/dkCPY62Ja1123jEnJbB9Vd2pjY7Kvk/lK3peA==",
       "dependencies": [
         "@supabase/auth-js",
         "@supabase/functions-js",
@@ -838,8 +838,8 @@
         "tslib"
       ]
     },
-    "@types/node@26.1.1": {
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+    "@types/node@26.1.2": {
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dependencies": [
         "undici-types"
       ]
@@ -875,7 +875,7 @@
         "vue-router"
       ]
     },
-    "@vitejs/plugin-vue@6.0.8_vite@8.1.5__@types+node@26.1.1_vue@3.5.40__typescript@6.0.3_@types+node@26.1.1_typescript@6.0.3": {
+    "@vitejs/plugin-vue@6.0.8_vite@8.1.5__@types+node@26.1.2_vue@3.5.40__typescript@6.0.3_@types+node@26.1.2": {
       "integrity": "sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==",
       "dependencies": [
         "@rolldown/pluginutils",
@@ -1586,8 +1586,8 @@
     "mimic-response@3.1.0": {
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
     },
-    "miniflare@4.20260722.0": {
-      "integrity": "sha512-LW6ABMhCx/yIEFBLC/DO4yAhdm2T/G7jp7pr5T2kj895+CCIaHZqpMXdW9O6YE48LcYcCJChwWc8aEs1vpbTXw==",
+    "miniflare@4.20260722.1": {
+      "integrity": "sha512-FJIg4omaCb2wwSyOeRosEdmVRi3JzGAOOH3pa3twmmtvWECl6BVZMIDwJbjByLKRyU+mrfk0M/n3oSiojFZvSA==",
       "dependencies": [
         "@cspotcode/source-map-support",
         "sharp",
@@ -1797,8 +1797,8 @@
         "source-map-js"
       ]
     },
-    "posthog-js@1.407.2": {
-      "integrity": "sha512-5deTvXopn+NJWEmCUw8Ix/ms3cv2+60WJ73Vgbvu2wSkZY/FIj2uqAgCnq7IewGpGC+tH7CAbPYFzH6hw8eW1w==",
+    "posthog-js@1.407.5": {
+      "integrity": "sha512-7YV0aSO8D9NPSawrIjgcOl81SKiPg6op8uFFc7e0qtu3ojYGE5+8MKfR3jEM67duvdkRAeWB9ZwBZQsg9pXu1g==",
       "dependencies": [
         "@posthog/browser-common",
         "@posthog/core",
@@ -2222,7 +2222,7 @@
         "spdx-expression-parse"
       ]
     },
-    "vite@8.1.5_@types+node@26.1.1": {
+    "vite@8.1.5_@types+node@26.1.2": {
       "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dependencies": [
         "@types/node",
@@ -2302,8 +2302,8 @@
       "scripts": true,
       "bin": true
     },
-    "wrangler@4.114.0": {
-      "integrity": "sha512-M65P25t5UHA1TIJfgZXDcj+YzVobgKdRguM2QPz0xnxLFuOcuE3ErgllDht0iaho7MS4o0g/Bb4YK2+GT+bibg==",
+    "wrangler@4.115.0": {
+      "integrity": "sha512-+upG2VW66M1sjb43yzgUZ6Ss8iYpJ6+7F3U4GF8TY5EYd+08sYdS54d24AEwCnhuef3J9KlSPusqiqR9WYy1UA==",
       "dependencies": [
         "@cloudflare/kv-asset-handler",
         "@cloudflare/unenv-preset",
@@ -2446,12 +2446,12 @@
   "workspace": {
     "packageJson": {
       "dependencies": [
-        "npm:@cloudflare/vite-plugin@^1.47.0",
+        "npm:@cloudflare/vite-plugin@^1.48.0",
         "npm:@cyclonedx/cyclonedx-npm@6.0.0",
         "npm:@playwright/test@^1.62.0",
         "npm:@sentry/vue@^10.68.0",
-        "npm:@supabase/supabase-js@^2.110.8",
-        "npm:@types/node@^26.1.1",
+        "npm:@supabase/supabase-js@^2.111.0",
+        "npm:@types/node@^26.1.2",
         "npm:@vercel/analytics@^2.0.1",
         "npm:@vercel/speed-insights@2",
         "npm:@vitejs/plugin-vue@^6.0.8",
@@ -2459,14 +2459,14 @@
         "npm:jsbarcode@^3.12.3",
         "npm:jspdf-autotable@^5.0.8",
         "npm:jspdf@^4.2.1",
-        "npm:posthog-js@^1.407.2",
+        "npm:posthog-js@^1.407.5",
         "npm:supabase@2.109.1",
         "npm:typescript@~6.0.3",
         "npm:vite@^8.1.5",
         "npm:vue-router@^4.6.4",
         "npm:vue-tsc@^3.3.8",
         "npm:vue@^3.5.40",
-        "npm:wrangler@^4.114.0",
+        "npm:wrangler@^4.115.0",
         "npm:zod@^4.4.3"
       ],
       "overrides": {

--- a/deno.lock
+++ b/deno.lock
@@ -1411,8 +1411,8 @@
     "iobuffer@5.4.0": {
       "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA=="
     },
-    "ip-address@10.2.0": {
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="
+    "ip-address@10.3.1": {
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g=="
     },
     "is-fullwidth-code-point@3.0.0": {
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
@@ -2480,7 +2480,8 @@
         "sharp": "0.35.3",
         "undici": "7.28.0",
         "node-gyp": "^13.0.1",
-        "brace-expansion": "^5.0.8"
+        "brace-expansion": "^5.0.8",
+        "ip-address": "^10.3.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,29 +9,29 @@
       "version": "0.0.0",
       "dependencies": {
         "@sentry/vue": "^10.68.0",
-        "@supabase/supabase-js": "^2.110.8",
+        "@supabase/supabase-js": "^2.111.0",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
         "jsbarcode": "^3.12.3",
         "jspdf": "^4.2.1",
         "jspdf-autotable": "^5.0.8",
-        "posthog-js": "^1.407.2",
+        "posthog-js": "^1.407.5",
         "vue": "^3.5.40",
         "vue-router": "^4.6.4",
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@cloudflare/vite-plugin": "^1.47.0",
+        "@cloudflare/vite-plugin": "^1.48.0",
         "@cyclonedx/cyclonedx-npm": "6.0.0",
         "@playwright/test": "^1.62.0",
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "@vitejs/plugin-vue": "^6.0.8",
         "@vue/tsconfig": "^0.9.1",
         "supabase": "2.109.1",
         "typescript": "~6.0.3",
         "vite": "^8.1.5",
         "vue-tsc": "^3.3.8",
-        "wrangler": "^4.114.0"
+        "wrangler": "^4.115.0"
       },
       "engines": {
         "node": "24.x"
@@ -119,17 +119,17 @@
       }
     },
     "node_modules/@cloudflare/vite-plugin": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.47.0.tgz",
-      "integrity": "sha512-WyGNYtJ2nzcJXtlwCHTO5S5+flFaYhfH5WfFfx6IpGf2Y/oNwyizEW9mNSImpg65PWmDs1715Pk/vGSKKtYJ1w==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.48.0.tgz",
+      "integrity": "sha512-Qt+lhot9ws3K4qOZYRuvsU03QsdLjQ63dgVrQo47kTL+SJmHScaQYG40mnJAKYL84mVT/ai7eFQORUxM6vMrWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cloudflare/unenv-preset": "2.16.1",
-        "miniflare": "4.20260722.0",
+        "miniflare": "4.20260722.1",
         "unenv": "2.0.0-rc.24",
         "workerd": "1.20260722.1",
-        "wrangler": "4.114.0",
+        "wrangler": "4.115.0",
         "ws": "8.21.0"
       },
       "bin": {
@@ -137,7 +137,7 @@
       },
       "peerDependencies": {
         "vite": "^6.1.0 || ^7.0.0 || ^8.0.0",
-        "wrangler": "^4.114.0"
+        "wrangler": "^4.115.0"
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
@@ -1596,9 +1596,9 @@
       "license": "MIT"
     },
     "node_modules/@posthog/browser-common": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.2.1.tgz",
-      "integrity": "sha512-FTVPsRw6GBKWvFwN26TNIQNNYPR9FsUj+B+CKhk/ht63IRzn4yYFtFOjcmW+bfXvNHuRADs6APbZ6Haz1kpoAw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.2.4.tgz",
+      "integrity": "sha512-/xI4sIVNiZMJButhNdQFdCHtOcB6v8xM8vtJKznqqB7SMbpYwUNok68iPxGNZHPDwUYM6GAqM/AbMiS80UNyMw==",
       "license": "MIT",
       "dependencies": {
         "@posthog/core": "^1.45.1",
@@ -1606,9 +1606,9 @@
       }
     },
     "node_modules/@posthog/core": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.45.1.tgz",
-      "integrity": "sha512-tLtvzomavb2PPWdGYKsusyIzIeL2Px47v348Smibkay7sMy/83TyPk+Ptsp2NdeOgJsbuwSxWkR2+XA0aSCAaA==",
+      "version": "1.45.2",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.45.2.tgz",
+      "integrity": "sha512-OhEHkojFkqEFbtm/wUtLYgomN1gFNU9IyufvNsuZvpIOh8TZ9tnAvI81Sej/2zu+vyDExs9JroQB5SW3y5QyOw==",
       "license": "MIT",
       "dependencies": {
         "@posthog/types": "^1.398.0"
@@ -2050,9 +2050,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.110.8",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.110.8.tgz",
-      "integrity": "sha512-TQ5neTUDX2C2WmyYa03yGhLMkhdE/SkHXtK8/qxO/APUy3rsymsJCBP48p4jcN6iO2G0ow6RRexQd2mX+dSyJg==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.111.0.tgz",
+      "integrity": "sha512-hbRLgyQZEX0SDyF4LYXpv94qOIQyFATfpT5SIs2V0SisHnisVRkYgiPQWzv80l4S2mO3qof78rmoH9j5zoFsYQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -2186,9 +2186,9 @@
       ]
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.110.8",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.110.8.tgz",
-      "integrity": "sha512-5yB9TLYzvv2oSQxwb0gamEvIAsuH66pVt7AM/pz03S7wN6ehD34GNgbShrccetqPedXQSz7e/1hAJ9NeEhoZVg==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.111.0.tgz",
+      "integrity": "sha512-RW/OCsd6MO592zU8ifzP8/f8XzxxIdpb+Up5XaOtE26Fw+3zTp475WX7+GuuktiD1WF8pFUDe6khUPbMp77RCw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -2204,9 +2204,9 @@
       "license": "MIT"
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.110.8",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.110.8.tgz",
-      "integrity": "sha512-QeRROxl1PpOZw5Jzi7BwdN9icsycMrLlCCvsjS0hYLW+nZoaT46zdagz/glJirj8jHF4jSd5Jyipuae2cBClCw==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.111.0.tgz",
+      "integrity": "sha512-pcqeDsnWP0lx9GawduYxNZJHeuTm53O7L0SC8RF8tniV3GWIPY6me6OTdnwzdwNUmNy1dzUVtSyIfE6+OflzPQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -2216,9 +2216,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.110.8",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.110.8.tgz",
-      "integrity": "sha512-mwX7ituX6O31fLf+0g65rpLlNxqgnMaPltPsQwzox6jfmbfVl3tCxXrfr3HEsQcCRjpjuJG1+A0vFzP1yVjKHA==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.111.0.tgz",
+      "integrity": "sha512-6oRf/vZyRwg8f8GbFSJkrD2w4HAu/yTvyMViHXHS+H5hNJzdXCrUR7cP5oW7daT3YlRnzRPY9LcGSJKZAmfMSg==",
       "license": "MIT",
       "dependencies": {
         "@supabase/phoenix": "0.4.5",
@@ -2229,9 +2229,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.110.8",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.8.tgz",
-      "integrity": "sha512-CcfhkZFBLxsthgUabZKxwfsoXdrikIGsL3LsGoV3FZTqCMx/s1y49taT4jT/oya5+1IuB0sFFHw6pF0o0iJniQ==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.111.0.tgz",
+      "integrity": "sha512-UEViNmTzVOxE8dqUA81wls+n9xgmlvSFfhfwo6QxrO4kQOytCYyw3ciYFoi4XoD4Jl95NJ3jnndHN5iIudWzqw==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -2242,16 +2242,16 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.110.8",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.110.8.tgz",
-      "integrity": "sha512-E5qzoe74zhJRv4wRcbO9eMYzeQDb/+h6c603pL8shcxLGBjTKsIF7XXj05IcNj23TLDgJN1WkMw7mwAPyu5dZg==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.111.0.tgz",
+      "integrity": "sha512-9q0/AULthQnWeiDh1vGyjoJZbSY04bu6qHcWit70pqEYn5Kv/dkCPY62Ja1123jEnJbB9Vd2pjY7Kvk/lK3peA==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.110.8",
-        "@supabase/functions-js": "2.110.8",
-        "@supabase/postgrest-js": "2.110.8",
-        "@supabase/realtime-js": "2.110.8",
-        "@supabase/storage-js": "2.110.8"
+        "@supabase/auth-js": "2.111.0",
+        "@supabase/functions-js": "2.111.0",
+        "@supabase/postgrest-js": "2.111.0",
+        "@supabase/realtime-js": "2.111.0",
+        "@supabase/storage-js": "2.111.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -2269,9 +2269,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3612,9 +3612,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260722.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260722.0.tgz",
-      "integrity": "sha512-LW6ABMhCx/yIEFBLC/DO4yAhdm2T/G7jp7pr5T2kj895+CCIaHZqpMXdW9O6YE48LcYcCJChwWc8aEs1vpbTXw==",
+      "version": "4.20260722.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260722.1.tgz",
+      "integrity": "sha512-FJIg4omaCb2wwSyOeRosEdmVRi3JzGAOOH3pa3twmmtvWECl6BVZMIDwJbjByLKRyU+mrfk0M/n3oSiojFZvSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3971,13 +3971,13 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "1.407.2",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.407.2.tgz",
-      "integrity": "sha512-5deTvXopn+NJWEmCUw8Ix/ms3cv2+60WJ73Vgbvu2wSkZY/FIj2uqAgCnq7IewGpGC+tH7CAbPYFzH6hw8eW1w==",
+      "version": "1.407.8",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.407.8.tgz",
+      "integrity": "sha512-I3rE1WQI9by/RrtgoE34opVmEsnCyUui5EkD3VYJWRiBIkglcn7A3Ixk7tniPEOfGMiDZFETX8ORAQBt47Z0VA==",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
-        "@posthog/browser-common": "^0.2.0",
-        "@posthog/core": "^1.45.1",
+        "@posthog/browser-common": "^0.2.4",
+        "@posthog/core": "^1.45.2",
         "@posthog/types": "^1.398.0",
         "core-js": "^3.49.0",
         "dompurify": "^3.3.2",
@@ -4908,9 +4908,9 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.114.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.114.0.tgz",
-      "integrity": "sha512-M65P25t5UHA1TIJfgZXDcj+YzVobgKdRguM2QPz0xnxLFuOcuE3ErgllDht0iaho7MS4o0g/Bb4YK2+GT+bibg==",
+      "version": "4.115.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.115.0.tgz",
+      "integrity": "sha512-+upG2VW66M1sjb43yzgUZ6Ss8iYpJ6+7F3U4GF8TY5EYd+08sYdS54d24AEwCnhuef3J9KlSPusqiqR9WYy1UA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -4918,7 +4918,7 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260722.0",
+        "miniflare": "4.20260722.1",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
         "workerd": "1.20260722.1"

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "sharp": "0.35.3",
     "undici": "7.28.0",
     "node-gyp": "^13.0.1",
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.8",
+    "ip-address": "^10.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,29 +43,29 @@
   },
   "dependencies": {
     "@sentry/vue": "^10.68.0",
-    "@supabase/supabase-js": "^2.110.8",
+    "@supabase/supabase-js": "^2.111.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "jsbarcode": "^3.12.3",
     "jspdf": "^4.2.1",
     "jspdf-autotable": "^5.0.8",
-    "posthog-js": "^1.407.2",
+    "posthog-js": "^1.407.5",
     "vue": "^3.5.40",
     "vue-router": "^4.6.4",
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "^1.47.0",
+    "@cloudflare/vite-plugin": "^1.48.0",
     "@cyclonedx/cyclonedx-npm": "6.0.0",
     "@playwright/test": "^1.62.0",
-    "@types/node": "^26.1.1",
+    "@types/node": "^26.1.2",
     "@vitejs/plugin-vue": "^6.0.8",
     "@vue/tsconfig": "^0.9.1",
     "supabase": "2.109.1",
     "typescript": "~6.0.3",
     "vite": "^8.1.5",
     "vue-tsc": "^3.3.8",
-    "wrangler": "^4.114.0"
+    "wrangler": "^4.115.0"
   },
   "overrides": {
     "esbuild": "0.28.1",


### PR DESCRIPTION
Aikido flagged 3 high-sev CVEs in ip-address@10.2.0, transitive dep via cyclonedx-npm's sbom chain (socks -> socks-proxy-agent -> node-gyp -> libxmljs2). Adds override alongside existing pins; deno.lock synced to match.