### PR TITLE
chore(deps): bump minor/patch deps- #835

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "specifiers": {
-    "npm:@cloudflare/vite-plugin@^1.49.0": "1.49.0_vite@8.2.0__@types+node@26.1.2_wrangler@4.116.0_@types+node@26.1.2",
+    "npm:@cloudflare/vite-plugin@^1.50.0": "1.50.0_vite@8.2.0__@types+node@26.1.2_wrangler@4.118.0",
     "npm:@cyclonedx/cyclonedx-npm@6.0.0": "6.0.0",
     "npm:@playwright/test@^1.62.1": "1.62.1",
     "npm:@sentry/vue@^10.69.0": "10.69.0_vue@3.5.40__typescript@6.0.3",
@@ -14,14 +14,14 @@
     "npm:jsbarcode@^3.12.3": "3.12.3",
     "npm:jspdf-autotable@^5.0.8": "5.0.8_jspdf@4.2.1",
     "npm:jspdf@^4.2.1": "4.2.1",
-    "npm:posthog-js@^1.409.0": "1.409.0",
-    "npm:supabase@^2.110.0": "2.110.0",
+    "npm:posthog-js@^1.409.5": "1.409.5",
+    "npm:supabase@^2.111.0": "2.111.0",
     "npm:typescript@~6.0.3": "6.0.3",
     "npm:vite@^8.2.0": "8.2.0_@types+node@26.1.2",
     "npm:vue-router@^4.6.4": "4.6.4_vue@3.5.40__typescript@6.0.3_typescript@6.0.3",
-    "npm:vue-tsc@^3.3.8": "3.3.8_typescript@6.0.3",
+    "npm:vue-tsc@^3.3.9": "3.3.9_typescript@6.0.3",
     "npm:vue@^3.5.40": "3.5.40_typescript@6.0.3",
-    "npm:wrangler@^4.116.0": "4.116.0",
+    "npm:wrangler@^4.118.0": "4.118.0",
     "npm:zod@^4.4.3": "4.4.3"
   },
   "npm": {
@@ -61,8 +61,8 @@
         "workerd"
       ]
     },
-    "@cloudflare/vite-plugin@1.49.0_vite@8.2.0__@types+node@26.1.2_wrangler@4.116.0_@types+node@26.1.2": {
-      "integrity": "sha512-r8w3fwkLPfiwG1ksvDqa82fcT//skvNWXe3nMcZqLsShexrecTkJs1ZK41YmKQP+DH2J1ggASoizmBTb1f7hQg==",
+    "@cloudflare/vite-plugin@1.50.0_vite@8.2.0__@types+node@26.1.2_wrangler@4.118.0": {
+      "integrity": "sha512-zIhZim7Kr7OC22rlOkU81BLj0oRlUOqPRX+E6RU3hyRYg4xU1MbA3yiMIwFONr+jc/uV7Fxs20NlXrB89Fqjqg==",
       "dependencies": [
         "@cloudflare/unenv-preset",
         "miniflare",
@@ -593,15 +593,15 @@
     "@poppinss/exception@1.2.3": {
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="
     },
-    "@posthog/browser-common@0.2.5": {
-      "integrity": "sha512-g95viLlEqPl92+ar3hEzlQbPqKB0Hp7AoYVaEmvXdjUiYfG3XP+qwzPRFmULNEGLDMSKL7T+MFHvs2/EswcE+g==",
+    "@posthog/browser-common@0.3.1": {
+      "integrity": "sha512-1nhMVY1wnHADTg8tR9yvm+lPAz5ROxznfQlBtLzB2FFo4lp/LU8lk9KyFPsARDkBxCfYachsJfvRjocL1G/AJQ==",
       "dependencies": [
         "@posthog/core",
         "@posthog/types"
       ]
     },
-    "@posthog/core@1.46.0": {
-      "integrity": "sha512-9w/bzHkf8V26YDAk7bO+Y2M0O9LMJg53lw3TOpirWRY77CEq4EQ3FkrtxP6BM48qaeZ/ILmRcfz+u1jjeTLetg==",
+    "@posthog/core@1.46.1": {
+      "integrity": "sha512-EoCFduRkvrg9E5ylMi4QnZCjlAdRJCq6tJouWfngBVR79XSI4iPvIWYA+CdzokAjk+TfSVBFVJ++4Im3r+T0Dg==",
       "dependencies": [
         "@posthog/types"
       ]
@@ -758,43 +758,43 @@
         "tslib"
       ]
     },
-    "@supabase/cli-darwin-arm64@2.110.0": {
-      "integrity": "sha512-VC+3vipRUtLrZKVYuxfRtP1gUPwUa+oZSeOJTRPSjLYN1FlnXIFcVDp/Xe21tZLYbVZBx3zJmy50OG2vTeNL3Q==",
+    "@supabase/cli-darwin-arm64@2.111.0": {
+      "integrity": "sha512-H1ucZ+9Z37Ha7uqYrKHfAy1vXWMVsN4gNlKaOpjKUYoHwDEbueEHVIDA1/PBIUd4HX+usJfpq+R+gWqzM/FKqQ==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "@supabase/cli-darwin-x64@2.110.0": {
-      "integrity": "sha512-PtDmolyEXqm6hpsNOTBB15xWadhbFOelaKaxBTflk1TBJO1Hugrzw4xophbi8hg4vG9HXh4GNc7TY24BA93zqA==",
+    "@supabase/cli-darwin-x64@2.111.0": {
+      "integrity": "sha512-4iMYm/XaAZJ8YzdJ2HBRVc7i9SRIwE6VQrnSt968WTt83M1y6knC7UENCKjMtO+As4QeZkICpUk50CeathqxbA==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "@supabase/cli-linux-arm64-musl@2.110.0": {
-      "integrity": "sha512-RyPgJr7hAdyhlxwUR36+s6P6rENupfN+meN+3+c/9XYT5cRwGuaJRnM4nsh9s1fs33lu7v22oy2N7IHZfgujew==",
+    "@supabase/cli-linux-arm64-musl@2.111.0": {
+      "integrity": "sha512-RnvbVlJ4TX/UIwLiglBVQ2eL4GAl9SfWZmM5LENXyIaohBcRZHDva5t2OyK+BPGBtngjVGpb3QyfLdvkt9yJcw==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@supabase/cli-linux-arm64@2.110.0": {
-      "integrity": "sha512-FHSVK7sR5quvAfDqwoA850ci3EP0hu6tjL1MDMWokkSwvILaHYp2AWq6jzZwa78dk+/SGeVPl8andkfyvH2qeg==",
+    "@supabase/cli-linux-arm64@2.111.0": {
+      "integrity": "sha512-2KSHITFMXe2u5yALupBWHGeQ1IY4C8GkcIWPWgNFdtAPo03pgs1hLWgL1eeqSh/a0wB/6rgUlM1fQR/hAgCyCA==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@supabase/cli-linux-x64-musl@2.110.0": {
-      "integrity": "sha512-GLYhJhOhQmkkH3gygZy8x0VLmnGuLk0giSGAc19FtA12qfXdVsVeTiZWBzIEFvrJ4nK8NWqf0K4HIe2C4sBFqg==",
+    "@supabase/cli-linux-x64-musl@2.111.0": {
+      "integrity": "sha512-2QVpsy/3v+TzqE5GgTCPruoxTlF3d8QPGirjcnah8hP66nxXStB9yTvxmJq+LtO3gwMt1Kpm7is0roZVkV55Pw==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@supabase/cli-linux-x64@2.110.0": {
-      "integrity": "sha512-mShXx1+8yQfpxEzVyBxH8plbrHoXE/6j/8jIzQXmzuOFbVyaJzJU3HMmuEUsptcgwj/FpWoE1HrI77TmzWrJ/w==",
+    "@supabase/cli-linux-x64@2.111.0": {
+      "integrity": "sha512-NwwNhiZZT4WYEPDXAbgZL+l77z/hoJ+w5t+52WBN1VlmoxwDmf2NP+UERM8wuCGFe/tmBlUuFE1eJYZfab0/qA==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@supabase/cli-windows-arm64@2.110.0": {
-      "integrity": "sha512-gLiQLv9geh3TV3t/uAd2GhNfLMJW/l8jyBclc2sPiljM5wosIKsxm8Uf9e97mgVVHgGLrRR1igXtru1YU+n8AQ==",
+    "@supabase/cli-windows-arm64@2.111.0": {
+      "integrity": "sha512-twawKY5xfU2dNOnZrKDmrudxRG/XIKcBxOb6X2lMGJU3N1Hd+8oWpI9TwM5Qv+eXehtlsKDmUvbitStXvJr/xQ==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "@supabase/cli-windows-x64@2.110.0": {
-      "integrity": "sha512-J4dXRahjAEQy3w0cTtJsvwCuoMY7OHAYPaR81Gxac0315HvSf+8Cf2cEpwAkUKpAhUpCE0pa1Gl3BrmKtd7qaw==",
+    "@supabase/cli-windows-x64@2.111.0": {
+      "integrity": "sha512-1F+X5tAYxAGx93ZZoIQBnIQ2Q2NnplKqjpigAS/zpTsNaWAjNi7EnxmuQKaEoAdqOHKbLhegVVDiw1+us3ZVpA==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
@@ -946,8 +946,8 @@
     "@vue/devtools-api@6.6.4": {
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="
     },
-    "@vue/language-core@3.3.8": {
-      "integrity": "sha512-ieGT8jJdhhy0mGzStZhsg/qPw5bQZJg5yF+3+XU6saf4sM7yo9ZXy3h+nCwrm2+b4qS/SypkNdR2jAF3uei9tA==",
+    "@vue/language-core@3.3.9": {
+      "integrity": "sha512-in/68oAa4BCtVY6n/nkuhLIkV8DHYd2UivedJ6cMZ6UYtlq9jaoaSNUBHYCVO44z3nKg7MdE5OBoHKt5SxeBKQ==",
       "dependencies": [
         "@volar/language-core",
         "@vue/compiler-dom",
@@ -1437,8 +1437,8 @@
         "@pkgjs/parseargs"
       ]
     },
-    "jose@6.2.5": {
-      "integrity": "sha512-2E5L2yRp03FnwreJLJX8/r7mHiZICCf8kG7fAsTWkSQTDAcc46NIZoQLKy+EJ8sPoJlxyS4OQR5H70LjIZZlIQ=="
+    "jose@6.2.6": {
+      "integrity": "sha512-HwMtbJjMw8rC8dUTwCNilHJD+fxTeKM3JV1eprSmTjS41qwXSSt6exJXgyPK1QOu0jB9eDYLESRDkB3qaT3jnw=="
     },
     "js-yaml@4.3.0": {
       "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
@@ -1591,8 +1591,8 @@
     "mimic-response@3.1.0": {
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
     },
-    "miniflare@4.20260730.0": {
-      "integrity": "sha512-1Z9SB9r/o//80UA02Re3QhtcecSHAyAjf5EcKBfQVlQrCg7Miy79hl2PvtkwFLIaJ5rcrOPdDcRr577okwZPsg==",
+    "miniflare@5.20260730.0-alpha": {
+      "integrity": "sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q==",
       "dependencies": [
         "@cspotcode/source-map-support",
         "sharp",
@@ -1600,8 +1600,7 @@
         "workerd",
         "ws",
         "youch"
-      ],
-      "bin": true
+      ]
     },
     "minimatch@9.0.9": {
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
@@ -1802,8 +1801,8 @@
         "source-map-js"
       ]
     },
-    "posthog-js@1.409.0": {
-      "integrity": "sha512-F21N6mTGikKiNW+u9z0hXuqY30USIRPf0shqKnB77XbTzNMK4Y56PVYYbHFwuIMwYNZH/TvufVJGcn4uq9+iAg==",
+    "posthog-js@1.409.5": {
+      "integrity": "sha512-s1iJz+vq0YAluUD4OwLjUFIJt/9pqiiB6MITvHWIS16a7pqTJqbSLXsd5/8kJcIgfrOSZHe+mdYAXLYcJCS4LQ==",
       "dependencies": [
         "@posthog/browser-common",
         "@posthog/core",
@@ -2102,8 +2101,8 @@
     "strip-json-comments@2.0.1": {
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
     },
-    "supabase@2.110.0": {
-      "integrity": "sha512-63QKsdLSVOFKTqABIAeOpg12daBZb9WYqc1NeMNimDP+gFGY8YsIh7VOJawUENXhIWWRlWNprHCOmafCc3LD7Q==",
+    "supabase@2.111.0": {
+      "integrity": "sha512-0cjCRdYNV1h2XXa0wm04mdct7QuDU7sMul/NwETRJmN3+HCsdEu6u5n0oygL97fdf6sDrGmnAdBh8E4wsv1ayg==",
       "dependencies": [
         "eciesjs",
         "jose"
@@ -2255,8 +2254,8 @@
         "vue"
       ]
     },
-    "vue-tsc@3.3.8_typescript@6.0.3": {
-      "integrity": "sha512-xXmYlVQpcwJDWyGlqbHrGVOl1h3UOsASymRibrHc+iy9j/UNnOrOn4u+fntHz4D6Cs74RtapeqVV6CzJeg+UlA==",
+    "vue-tsc@3.3.9_typescript@6.0.3": {
+      "integrity": "sha512-TS3Y1ux/IRoE8OCP2PpACAeOseuIs0UvWrcr7u+w3PmfY+SlCfEf8zjrBgnQksHUgLpthi5vHlffcQTQTdPBZA==",
       "dependencies": [
         "@volar/typescript",
         "@vue/language-core",
@@ -2307,8 +2306,8 @@
       "scripts": true,
       "bin": true
     },
-    "wrangler@4.116.0": {
-      "integrity": "sha512-wP1PXxH5KJajfGEjty0NNqyxAirTFvMZpGyB5CRqEIiY0fL/SiCKtIYAJB9HXq0MP0sMXB/i/YSls+WObahAhw==",
+    "wrangler@4.118.0": {
+      "integrity": "sha512-9pkBw/b8zWqGx2S+oLhgHMR1M/4VOE8SynUFABnGWiSFGlcOQ4xiI/B71Xf66RYP2xzngU37IQFPtUruij3lYw==",
       "dependencies": [
         "@cloudflare/kv-asset-handler",
         "@cloudflare/unenv-preset",
@@ -2451,7 +2450,7 @@
   "workspace": {
     "packageJson": {
       "dependencies": [
-        "npm:@cloudflare/vite-plugin@^1.49.0",
+        "npm:@cloudflare/vite-plugin@^1.50.0",
         "npm:@cyclonedx/cyclonedx-npm@6.0.0",
         "npm:@playwright/test@^1.62.1",
         "npm:@sentry/vue@^10.69.0",
@@ -2464,14 +2463,14 @@
         "npm:jsbarcode@^3.12.3",
         "npm:jspdf-autotable@^5.0.8",
         "npm:jspdf@^4.2.1",
-        "npm:posthog-js@^1.409.0",
-        "npm:supabase@^2.110.0",
+        "npm:posthog-js@^1.409.5",
+        "npm:supabase@^2.111.0",
         "npm:typescript@~6.0.3",
         "npm:vite@^8.2.0",
         "npm:vue-router@^4.6.4",
-        "npm:vue-tsc@^3.3.8",
+        "npm:vue-tsc@^3.3.9",
         "npm:vue@^3.5.40",
-        "npm:wrangler@^4.116.0",
+        "npm:wrangler@^4.118.0",
         "npm:zod@^4.4.3"
       ],
       "overrides": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,23 +15,23 @@
         "jsbarcode": "^3.12.3",
         "jspdf": "^4.2.1",
         "jspdf-autotable": "^5.0.8",
-        "posthog-js": "^1.409.0",
+        "posthog-js": "^1.409.5",
         "vue": "^3.5.40",
         "vue-router": "^4.6.4",
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@cloudflare/vite-plugin": "^1.49.0",
+        "@cloudflare/vite-plugin": "^1.50.0",
         "@cyclonedx/cyclonedx-npm": "6.0.0",
         "@playwright/test": "^1.62.1",
         "@types/node": "^26.1.2",
         "@vitejs/plugin-vue": "^6.0.8",
         "@vue/tsconfig": "^0.9.1",
-        "supabase": "^2.110.0",
+        "supabase": "^2.111.0",
         "typescript": "~6.0.3",
         "vite": "^8.2.0",
-        "vue-tsc": "^3.3.8",
-        "wrangler": "^4.116.0"
+        "vue-tsc": "^3.3.9",
+        "wrangler": "^4.118.0"
       },
       "engines": {
         "node": "24.x"
@@ -119,17 +119,17 @@
       }
     },
     "node_modules/@cloudflare/vite-plugin": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.49.0.tgz",
-      "integrity": "sha512-r8w3fwkLPfiwG1ksvDqa82fcT//skvNWXe3nMcZqLsShexrecTkJs1ZK41YmKQP+DH2J1ggASoizmBTb1f7hQg==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.50.0.tgz",
+      "integrity": "sha512-zIhZim7Kr7OC22rlOkU81BLj0oRlUOqPRX+E6RU3hyRYg4xU1MbA3yiMIwFONr+jc/uV7Fxs20NlXrB89Fqjqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cloudflare/unenv-preset": "2.16.1",
-        "miniflare": "4.20260730.0",
+        "miniflare": "5.20260730.0-alpha",
         "unenv": "2.0.0-rc.24",
         "workerd": "1.20260730.1",
-        "wrangler": "4.116.0",
+        "wrangler": "4.118.0",
         "ws": "8.21.0"
       },
       "bin": {
@@ -137,7 +137,7 @@
       },
       "peerDependencies": {
         "vite": "^6.1.0 || ^7.0.0 || ^8.0.0",
-        "wrangler": "^4.116.0"
+        "wrangler": "^4.118.0"
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
@@ -1599,19 +1599,19 @@
       "license": "MIT"
     },
     "node_modules/@posthog/browser-common": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.2.5.tgz",
-      "integrity": "sha512-g95viLlEqPl92+ar3hEzlQbPqKB0Hp7AoYVaEmvXdjUiYfG3XP+qwzPRFmULNEGLDMSKL7T+MFHvs2/EswcE+g==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.3.1.tgz",
+      "integrity": "sha512-1nhMVY1wnHADTg8tR9yvm+lPAz5ROxznfQlBtLzB2FFo4lp/LU8lk9KyFPsARDkBxCfYachsJfvRjocL1G/AJQ==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/core": "^1.45.3",
+        "@posthog/core": "^1.46.0",
         "@posthog/types": "^1.399.0"
       }
     },
     "node_modules/@posthog/core": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.46.0.tgz",
-      "integrity": "sha512-9w/bzHkf8V26YDAk7bO+Y2M0O9LMJg53lw3TOpirWRY77CEq4EQ3FkrtxP6BM48qaeZ/ILmRcfz+u1jjeTLetg==",
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.46.1.tgz",
+      "integrity": "sha512-EoCFduRkvrg9E5ylMi4QnZCjlAdRJCq6tJouWfngBVR79XSI4iPvIWYA+CdzokAjk+TfSVBFVJ++4Im3r+T0Dg==",
       "license": "MIT",
       "dependencies": {
         "@posthog/types": "^1.399.0"
@@ -2062,9 +2062,9 @@
       }
     },
     "node_modules/@supabase/cli-darwin-arm64": {
-      "version": "2.110.0",
-      "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-arm64/-/cli-darwin-arm64-2.110.0.tgz",
-      "integrity": "sha512-VC+3vipRUtLrZKVYuxfRtP1gUPwUa+oZSeOJTRPSjLYN1FlnXIFcVDp/Xe21tZLYbVZBx3zJmy50OG2vTeNL3Q==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-arm64/-/cli-darwin-arm64-2.111.0.tgz",
+      "integrity": "sha512-H1ucZ+9Z37Ha7uqYrKHfAy1vXWMVsN4gNlKaOpjKUYoHwDEbueEHVIDA1/PBIUd4HX+usJfpq+R+gWqzM/FKqQ==",
       "cpu": [
         "arm64"
       ],
@@ -2076,9 +2076,9 @@
       ]
     },
     "node_modules/@supabase/cli-darwin-x64": {
-      "version": "2.110.0",
-      "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-x64/-/cli-darwin-x64-2.110.0.tgz",
-      "integrity": "sha512-PtDmolyEXqm6hpsNOTBB15xWadhbFOelaKaxBTflk1TBJO1Hugrzw4xophbi8hg4vG9HXh4GNc7TY24BA93zqA==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-x64/-/cli-darwin-x64-2.111.0.tgz",
+      "integrity": "sha512-4iMYm/XaAZJ8YzdJ2HBRVc7i9SRIwE6VQrnSt968WTt83M1y6knC7UENCKjMtO+As4QeZkICpUk50CeathqxbA==",
       "cpu": [
         "x64"
       ],
@@ -2090,9 +2090,9 @@
       ]
     },
     "node_modules/@supabase/cli-linux-arm64": {
-      "version": "2.110.0",
-      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64/-/cli-linux-arm64-2.110.0.tgz",
-      "integrity": "sha512-FHSVK7sR5quvAfDqwoA850ci3EP0hu6tjL1MDMWokkSwvILaHYp2AWq6jzZwa78dk+/SGeVPl8andkfyvH2qeg==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64/-/cli-linux-arm64-2.111.0.tgz",
+      "integrity": "sha512-2KSHITFMXe2u5yALupBWHGeQ1IY4C8GkcIWPWgNFdtAPo03pgs1hLWgL1eeqSh/a0wB/6rgUlM1fQR/hAgCyCA==",
       "cpu": [
         "arm64"
       ],
@@ -2107,9 +2107,9 @@
       ]
     },
     "node_modules/@supabase/cli-linux-arm64-musl": {
-      "version": "2.110.0",
-      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.110.0.tgz",
-      "integrity": "sha512-RyPgJr7hAdyhlxwUR36+s6P6rENupfN+meN+3+c/9XYT5cRwGuaJRnM4nsh9s1fs33lu7v22oy2N7IHZfgujew==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.111.0.tgz",
+      "integrity": "sha512-RnvbVlJ4TX/UIwLiglBVQ2eL4GAl9SfWZmM5LENXyIaohBcRZHDva5t2OyK+BPGBtngjVGpb3QyfLdvkt9yJcw==",
       "cpu": [
         "arm64"
       ],
@@ -2124,9 +2124,9 @@
       ]
     },
     "node_modules/@supabase/cli-linux-x64": {
-      "version": "2.110.0",
-      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64/-/cli-linux-x64-2.110.0.tgz",
-      "integrity": "sha512-mShXx1+8yQfpxEzVyBxH8plbrHoXE/6j/8jIzQXmzuOFbVyaJzJU3HMmuEUsptcgwj/FpWoE1HrI77TmzWrJ/w==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64/-/cli-linux-x64-2.111.0.tgz",
+      "integrity": "sha512-NwwNhiZZT4WYEPDXAbgZL+l77z/hoJ+w5t+52WBN1VlmoxwDmf2NP+UERM8wuCGFe/tmBlUuFE1eJYZfab0/qA==",
       "cpu": [
         "x64"
       ],
@@ -2141,9 +2141,9 @@
       ]
     },
     "node_modules/@supabase/cli-linux-x64-musl": {
-      "version": "2.110.0",
-      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64-musl/-/cli-linux-x64-musl-2.110.0.tgz",
-      "integrity": "sha512-GLYhJhOhQmkkH3gygZy8x0VLmnGuLk0giSGAc19FtA12qfXdVsVeTiZWBzIEFvrJ4nK8NWqf0K4HIe2C4sBFqg==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64-musl/-/cli-linux-x64-musl-2.111.0.tgz",
+      "integrity": "sha512-2QVpsy/3v+TzqE5GgTCPruoxTlF3d8QPGirjcnah8hP66nxXStB9yTvxmJq+LtO3gwMt1Kpm7is0roZVkV55Pw==",
       "cpu": [
         "x64"
       ],
@@ -2158,9 +2158,9 @@
       ]
     },
     "node_modules/@supabase/cli-windows-arm64": {
-      "version": "2.110.0",
-      "resolved": "https://registry.npmjs.org/@supabase/cli-windows-arm64/-/cli-windows-arm64-2.110.0.tgz",
-      "integrity": "sha512-gLiQLv9geh3TV3t/uAd2GhNfLMJW/l8jyBclc2sPiljM5wosIKsxm8Uf9e97mgVVHgGLrRR1igXtru1YU+n8AQ==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-windows-arm64/-/cli-windows-arm64-2.111.0.tgz",
+      "integrity": "sha512-twawKY5xfU2dNOnZrKDmrudxRG/XIKcBxOb6X2lMGJU3N1Hd+8oWpI9TwM5Qv+eXehtlsKDmUvbitStXvJr/xQ==",
       "cpu": [
         "arm64"
       ],
@@ -2172,9 +2172,9 @@
       ]
     },
     "node_modules/@supabase/cli-windows-x64": {
-      "version": "2.110.0",
-      "resolved": "https://registry.npmjs.org/@supabase/cli-windows-x64/-/cli-windows-x64-2.110.0.tgz",
-      "integrity": "sha512-J4dXRahjAEQy3w0cTtJsvwCuoMY7OHAYPaR81Gxac0315HvSf+8Cf2cEpwAkUKpAhUpCE0pa1Gl3BrmKtd7qaw==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-windows-x64/-/cli-windows-x64-2.111.0.tgz",
+      "integrity": "sha512-1F+X5tAYxAGx93ZZoIQBnIQ2Q2NnplKqjpigAS/zpTsNaWAjNi7EnxmuQKaEoAdqOHKbLhegVVDiw1+us3ZVpA==",
       "cpu": [
         "x64"
       ],
@@ -2481,9 +2481,9 @@
       "license": "MIT"
     },
     "node_modules/@vue/language-core": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.8.tgz",
-      "integrity": "sha512-ieGT8jJdhhy0mGzStZhsg/qPw5bQZJg5yF+3+XU6saf4sM7yo9ZXy3h+nCwrm2+b4qS/SypkNdR2jAF3uei9tA==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.9.tgz",
+      "integrity": "sha512-in/68oAa4BCtVY6n/nkuhLIkV8DHYd2UivedJ6cMZ6UYtlq9jaoaSNUBHYCVO44z3nKg7MdE5OBoHKt5SxeBKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3612,9 +3612,9 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260730.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260730.0.tgz",
-      "integrity": "sha512-1Z9SB9r/o//80UA02Re3QhtcecSHAyAjf5EcKBfQVlQrCg7Miy79hl2PvtkwFLIaJ5rcrOPdDcRr577okwZPsg==",
+      "version": "5.20260730.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260730.0-alpha.tgz",
+      "integrity": "sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3624,9 +3624,6 @@
         "workerd": "1.20260730.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -3971,13 +3968,13 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "1.409.0",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.409.0.tgz",
-      "integrity": "sha512-F21N6mTGikKiNW+u9z0hXuqY30USIRPf0shqKnB77XbTzNMK4Y56PVYYbHFwuIMwYNZH/TvufVJGcn4uq9+iAg==",
+      "version": "1.409.5",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.409.5.tgz",
+      "integrity": "sha512-s1iJz+vq0YAluUD4OwLjUFIJt/9pqiiB6MITvHWIS16a7pqTJqbSLXsd5/8kJcIgfrOSZHe+mdYAXLYcJCS4LQ==",
       "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
-        "@posthog/browser-common": "^0.2.5",
-        "@posthog/core": "^1.46.0",
+        "@posthog/browser-common": "^0.3.1",
+        "@posthog/core": "^1.46.1",
         "@posthog/types": "^1.399.0",
         "core-js": "^3.49.0",
         "dompurify": "^3.3.2",
@@ -4467,9 +4464,9 @@
       }
     },
     "node_modules/supabase": {
-      "version": "2.110.0",
-      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.110.0.tgz",
-      "integrity": "sha512-63QKsdLSVOFKTqABIAeOpg12daBZb9WYqc1NeMNimDP+gFGY8YsIh7VOJawUENXhIWWRlWNprHCOmafCc3LD7Q==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.111.0.tgz",
+      "integrity": "sha512-0cjCRdYNV1h2XXa0wm04mdct7QuDU7sMul/NwETRJmN3+HCsdEu6u5n0oygL97fdf6sDrGmnAdBh8E4wsv1ayg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4480,14 +4477,14 @@
         "supabase": "dist/supabase.js"
       },
       "optionalDependencies": {
-        "@supabase/cli-darwin-arm64": "2.110.0",
-        "@supabase/cli-darwin-x64": "2.110.0",
-        "@supabase/cli-linux-arm64": "2.110.0",
-        "@supabase/cli-linux-arm64-musl": "2.110.0",
-        "@supabase/cli-linux-x64": "2.110.0",
-        "@supabase/cli-linux-x64-musl": "2.110.0",
-        "@supabase/cli-windows-arm64": "2.110.0",
-        "@supabase/cli-windows-x64": "2.110.0"
+        "@supabase/cli-darwin-arm64": "2.111.0",
+        "@supabase/cli-darwin-x64": "2.111.0",
+        "@supabase/cli-linux-arm64": "2.111.0",
+        "@supabase/cli-linux-arm64-musl": "2.111.0",
+        "@supabase/cli-linux-x64": "2.111.0",
+        "@supabase/cli-linux-x64-musl": "2.111.0",
+        "@supabase/cli-windows-arm64": "2.111.0",
+        "@supabase/cli-windows-x64": "2.111.0"
       }
     },
     "node_modules/supports-color": {
@@ -4847,14 +4844,14 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.8.tgz",
-      "integrity": "sha512-xXmYlVQpcwJDWyGlqbHrGVOl1h3UOsASymRibrHc+iy9j/UNnOrOn4u+fntHz4D6Cs74RtapeqVV6CzJeg+UlA==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.9.tgz",
+      "integrity": "sha512-TS3Y1ux/IRoE8OCP2PpACAeOseuIs0UvWrcr7u+w3PmfY+SlCfEf8zjrBgnQksHUgLpthi5vHlffcQTQTdPBZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "2.4.28",
-        "@vue/language-core": "3.3.8"
+        "@vue/language-core": "3.3.9"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"
@@ -4908,9 +4905,9 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.116.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.116.0.tgz",
-      "integrity": "sha512-wP1PXxH5KJajfGEjty0NNqyxAirTFvMZpGyB5CRqEIiY0fL/SiCKtIYAJB9HXq0MP0sMXB/i/YSls+WObahAhw==",
+      "version": "4.118.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.118.0.tgz",
+      "integrity": "sha512-9pkBw/b8zWqGx2S+oLhgHMR1M/4VOE8SynUFABnGWiSFGlcOQ4xiI/B71Xf66RYP2xzngU37IQFPtUruij3lYw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -4918,7 +4915,7 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260730.0",
+        "miniflare": "5.20260730.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
         "workerd": "1.20260730.1"

--- a/package.json
+++ b/package.json
@@ -49,23 +49,23 @@
     "jsbarcode": "^3.12.3",
     "jspdf": "^4.2.1",
     "jspdf-autotable": "^5.0.8",
-    "posthog-js": "^1.409.0",
+    "posthog-js": "^1.409.5",
     "vue": "^3.5.40",
     "vue-router": "^4.6.4",
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "^1.49.0",
+    "@cloudflare/vite-plugin": "^1.50.0",
     "@cyclonedx/cyclonedx-npm": "6.0.0",
     "@playwright/test": "^1.62.1",
     "@types/node": "^26.1.2",
     "@vitejs/plugin-vue": "^6.0.8",
     "@vue/tsconfig": "^0.9.1",
-    "supabase": "^2.110.0",
+    "supabase": "^2.111.0",
     "typescript": "~6.0.3",
     "vite": "^8.2.0",
-    "vue-tsc": "^3.3.8",
-    "wrangler": "^4.116.0"
+    "vue-tsc": "^3.3.9",
+    "wrangler": "^4.118.0"
   },
   "overrides": {
     "esbuild": "0.28.1",


### PR DESCRIPTION
This pull request updates several dependencies in the `package.json` file to their latest patch or minor versions. These updates help ensure compatibility, access to new features, and important bug fixes.

Dependency updates:

* Upgraded `posthog-js` from version `^1.409.0` to `^1.409.5` for improved analytics tracking and bug fixes.
* Updated `@cloudflare/vite-plugin` from `^1.49.0` to `^1.50.0` to maintain compatibility with the latest Vite and Cloudflare features.
* Upgraded `supabase` from `^2.110.0` to `^2.111.0` for the latest backend features and fixes.
* Updated `vue-tsc` from `^3.3.8` to `^3.3.9` for improved TypeScript support with Vue.
* Upgraded `wrangler` from `^4.116.0` to `^4.118.0` for Cloudflare Workers development improvements.