### PR TITLE
Update probes configuration and disable Strix security scan

### DIFF
--- a/.github/workflows/strix-security.yml
+++ b/.github/workflows/strix-security.yml
@@ -23,10 +23,11 @@ jobs:
 
   strix-security-scan:
     needs: kill-switch-preflight
-    # Re-enabled for retest on Strix v1.4.1 (was gated off due to a Caido
-    # bootstrap race on the shared sandbox image, confirmed independent of
-    # CLI version on v1.1.0/v1.0.4): https://github.com/usestrix/strix/issues/927
-    if: (github.event_name == 'workflow_dispatch' || (github.event.pull_request.base.ref == 'preview' && github.event.pull_request.head.ref == 'staging')) && needs.kill-switch-preflight.outputs.active == 'false'
+    # Temporarily disabled: Strix v1.4.1 aborts on the known unknown-tool
+    # ModelBehaviorError reproduced in ItemTraxx CI. Re-enable after the
+    # upstream recovery fix lands: https://github.com/usestrix/strix/issues/580
+    # and https://github.com/usestrix/strix/pull/613
+    if: false && ((github.event_name == 'workflow_dispatch' || (github.event.pull_request.base.ref == 'preview' && github.event.pull_request.head.ref == 'staging')) && needs.kill-switch-preflight.outputs.active == 'false')
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/synthetic-probes.yml
+++ b/.github/workflows/synthetic-probes.yml
@@ -12,8 +12,12 @@ jobs:
     uses: ItemTraxxCo/devops/.github/workflows/reusable-synthetic-probes.yml@e3541101f8eb325db2eb047754ce9003fb6a31c3
     with:
       hub_ref: e3541101f8eb325db2eb047754ce9003fb6a31c3
+      # GitHub-hosted runners are challenged by Cloudflare's managed firewall
+      # before the public edge can return an application response. Keep this
+      # required check on the origin health signal; Deployment Health covers
+      # the public routes separately with challenge-aware handling.
       probes_config: >-
-        {"statusUrl":"https://edge.itemtraxx.com/functions/system-status","origin":"https://itemtraxx.com","probes":[{"name":"edge-system-status","url":"https://edge.itemtraxx.com/functions/system-status","headers":{"Accept":"application/json"},"expect":{"statusRange":[200,299]},"bodyContains":"kill_switch","attempts":3,"allowKillSwitchSkip":true},{"name":"origin-contact-sales-validation","url":"https://mlaspkufocikfcbjgpof.supabase.co/functions/v1/contact-sales-submit","method":"POST","body":"{\"plan\":\"core\"}","expect":{"statusRange":[200,499]},"attempts":3,"allowKillSwitchSkip":true}]}
+        {"statusUrl":"https://mlaspkufocikfcbjgpof.supabase.co/functions/v1/system-status","origin":"https://itemtraxx.com","probes":[{"name":"origin-system-status","url":"https://mlaspkufocikfcbjgpof.supabase.co/functions/v1/system-status","headers":{"Accept":"application/json"},"expect":{"statusRange":[200,299]},"bodyContains":"kill_switch","attempts":3,"allowKillSwitchSkip":true},{"name":"origin-contact-sales-validation","url":"https://mlaspkufocikfcbjgpof.supabase.co/functions/v1/contact-sales-submit","method":"POST","body":"{\"plan\":\"core\"}","expect":{"statusRange":[200,499]},"attempts":3,"allowKillSwitchSkip":true}]}
 
   slack-notify-failure:
     needs:


### PR DESCRIPTION
This pull request updates the CI workflow configuration for both security scanning and synthetic probe jobs. The main changes involve temporarily disabling the Strix security scan due to an upstream tool issue and updating the synthetic probe configuration to improve origin health checks and clarify Cloudflare handling.

**Security scanning:**

* The `strix-security-scan` job in `.github/workflows/strix-security.yml` is now forcibly disabled by setting `if: false`, due to a known upstream `ModelBehaviorError` in Strix v1.4.1. The comments reference the relevant upstream issues for tracking re-enablement.

**Synthetic probes:**

* The `probes_config` in `.github/workflows/synthetic-probes.yml` has been updated to:
  - Point the system status probe to the Supabase origin (`system-status` function) instead of the edge.
  - Rename the probe to `origin-system-status` and update its URL accordingly.
  - Add comments clarifying the impact of Cloudflare's managed firewall on GitHub-hosted runners and the separation of origin vs. public edge health checks.