### PR TITLE
fix(ci): update kill-switch-preflight job to use Supabase as status source

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,12 @@ concurrency:
 
 jobs:
   kill-switch-preflight:
+    # GitHub-hosted runners receive a Cloudflare challenge (HTTP 403) from
+    # the edge system-status URL. Use the direct Supabase origin, as CI Core
+    # does, while keeping CodeQL fail-closed on an unknown state.
     uses: ./.github/workflows/kill-switch-preflight.yml
+    with:
+      status_source: supabase
 
   slack-notify-start:
     needs: kill-switch-preflight

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,12 @@ concurrency:
 
 jobs:
   kill-switch-preflight:
+    # GitHub-hosted runners receive a Cloudflare challenge (HTTP 403) from
+    # the edge system-status URL. Use the direct Supabase origin, as CI Core
+    # does, while keeping E2E fail-closed on an unknown state.
     uses: ./.github/workflows/kill-switch-preflight.yml
+    with:
+      status_source: supabase
 
   slack-notify-start:
     needs: kill-switch-preflight


### PR DESCRIPTION
This pull request updates the `kill-switch-preflight` job configuration in both the `codeql.yml` and `e2e.yml` GitHub Actions workflows to improve reliability when running on GitHub-hosted runners. The main change is to use the direct Supabase origin for status checks, avoiding issues with Cloudflare challenges.

Workflow reliability improvements:

* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27R24-R29): Updated the `kill-switch-preflight` job to use the direct Supabase origin for the status check by setting `status_source: supabase`, which helps avoid HTTP 403 errors from Cloudflare when running on GitHub-hosted runners.
* [`.github/workflows/e2e.yml`](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eR21-R26): Made the same update to the `kill-switch-preflight` job for end-to-end tests, ensuring consistent and reliable status checks in CI.