### PR TITLE
Fix account category label and update dependencies

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -90,7 +90,7 @@ jobs:
         run: npm run build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
         with:
           category: '/language:${{ matrix.language }}'
 

--- a/deno.lock
+++ b/deno.lock
@@ -1430,8 +1430,8 @@
     "discontinuous-range@1.0.0": {
       "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
     },
-    "dompurify@3.4.12": {
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+    "dompurify@3.4.13": {
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "optionalDependencies": [
         "@types/trusted-types"
       ]
@@ -2997,7 +2997,7 @@
         "tar-fs": "^2.1.5",
         "protobufjs@<=8.2.0": "8.2.0",
         "ws": "^8.20.1",
-        "dompurify": "3.4.12",
+        "dompurify": "3.4.13",
         "fast-uri": "3.1.5",
         "sharp": "0.35.3",
         "undici": "7.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3544,9 +3544,9 @@
       "optional": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "tar-fs": "^2.1.5",
     "protobufjs@<=8.2.0": "8.2.0",
     "ws": "^8.20.1",
-    "dompurify": "3.4.12",
+    "dompurify": "3.4.13",
     "fast-uri": "3.1.5",
     "sharp": "0.35.3",
     "undici": "7.29.0",

--- a/src/pages/workspace/admin/Settings.vue
+++ b/src/pages/workspace/admin/Settings.vue
@@ -29,7 +29,7 @@
       <div class="admin-summary-grid">
         <div class="admin-summary-card">
           <strong>{{ accountCategoryLabel }}</strong>
-          <span></span>
+          <span>Account Category</span>
         </div>
         <div class="admin-summary-card">
           <strong>{{ planLabel }}</strong>


### PR DESCRIPTION
This pull request includes minor dependency updates, workflow improvements, and a small UI fix. The most important changes are:

**Dependency Updates:**
* Upgraded the `dompurify` package from version `3.4.12` to `3.4.13` in `package.json` for improved security and bug fixes. **This addresses the Aikido Finding and https://github.com/advisories/GHSA-55q2-fjhq-7xh7**

**CI/CD Workflow Improvements:**
* Updated the `github/codeql-action/init` and `github/codeql-action/analyze` actions to use a newer commit hash in `.github/workflows/codeql.yml` for better stability and latest features. [[1]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L72-R72) [[2]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L93-R93)

**UI Fixes:**
* Changed the admin summary card in `Settings.vue` to display the text "Account Category" instead of leaving the field blank, improving clarity for users.