### PR TITLE
ci: re-enable Strix v1.5.1 scan and use GLM-5.2 for scan

### DIFF
--- a/.github/workflows/strix-security.yml
+++ b/.github/workflows/strix-security.yml
@@ -23,11 +23,9 @@ jobs:
 
   strix-security-scan:
     needs: kill-switch-preflight
-    # Temporarily disabled: Strix v1.4.1 aborts on the known unknown-tool
-    # ModelBehaviorError reproduced in ItemTraxx CI. Re-enable after the
-    # upstream recovery fix lands: https://github.com/usestrix/strix/issues/580
-    # and https://github.com/usestrix/strix/pull/613
-    if: false && ((github.event_name == 'workflow_dispatch' || (github.event.pull_request.base.ref == 'preview' && github.event.pull_request.head.ref == 'staging')) && needs.kill-switch-preflight.outputs.active == 'false')
+    # Strix v1.5.1 includes recoverable unknown-tool handling for the
+    # ModelBehaviorError reproduced in ItemTraxx CI.
+    if: ((github.event_name == 'workflow_dispatch' || (github.event.pull_request.base.ref == 'preview' && github.event.pull_request.head.ref == 'staging')) && needs.kill-switch-preflight.outputs.active == 'false')
     permissions:
       contents: read
       pull-requests: write
@@ -44,9 +42,9 @@ jobs:
 
       - name: Install Strix
         env:
-          STRIX_VERSION: 1.4.1
-          # SHA-256 published for strix-1.4.1-linux-x86_64.tar.gz.
-          STRIX_SHA256: 6a50b8444700ee311d155b3828f0ed7e7876dcbe60404934b16d9aa0f442c1fe
+          STRIX_VERSION: 1.5.1
+          # SHA-256 published for strix-1.5.1-linux-x86_64.tar.gz.
+          STRIX_SHA256: f898f2913fc470986df3e903403b8b54409dc26c40caf2f8759e08d3814a3322
         run: |
           strix_dir="$RUNNER_TEMP/strix-${STRIX_VERSION}"
           strix_archive="$strix_dir/strix.tar.gz"

--- a/.github/workflows/strix-security.yml
+++ b/.github/workflows/strix-security.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run Strix security scan
         id: strix-scan
         env:
-          STRIX_LLM: nvidia_nim/deepseek-ai/deepseek-v4-flash
+          STRIX_LLM: nvidia_nim/z-ai/glm-5.2
           LLM_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
           STRIX_REASONING_EFFORT: medium
           STRIX_DIFF_BASE: origin/${{ github.base_ref || github.event.repository.default_branch }}


### PR DESCRIPTION
This pull request updates the Strix security scan workflow to re-enable scanning with a newer Strix version, improve error handling, and switch to a different LLM model. The most important changes are grouped below:

**Strix Security Scan Reactivation and Version Update:**

* Re-enabled the `strix-security-scan` job by removing the temporary disablement, as Strix v1.5.1 now handles the previously blocking `ModelBehaviorError`.
* Updated the installed Strix version from `1.4.1` to `1.5.1` and replaced the SHA-256 checksum to match the new release.
* Prevously paused due to issues on Strix's end.

**LLM Model Change:**

* Changed the LLM used for the security scan from `nvidia_nim/deepseek-ai/deepseek-v4-flash` to `nvidia_nim/z-ai/glm-5.2` due to Nvidia discontinuing the NIM endpoint for `deepseek-v4-flash`.