### PR TITLE
ci: expose Supabase migration response status

### DIFF
--- a/.github/workflows/deploy-supabase-target.yml
+++ b/.github/workflows/deploy-supabase-target.yml
@@ -64,12 +64,21 @@ jobs:
             --rawfile query "$MIGRATION_PATH" \
             --arg name "$MIGRATION_NAME" \
             '{query: $query, name: $name}')"
-          response="$(curl --fail-with-body -sS \
+          response_file="$(mktemp)"
+          trap 'rm -f "$response_file"' EXIT
+          http_status="$(curl -sS \
             -X POST "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/database/migrations" \
             -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
             -H "Content-Type: application/json" \
-            --data "$payload")"
-          printf '%s\n' "$response" | cut -c1-1000
+            --data "$payload" \
+            -o "$response_file" \
+            -w '%{http_code}' || true)"
+          printf 'Supabase migration API response (HTTP %s):\n' "$http_status"
+          cut -c1-2000 "$response_file"
+          if [[ ! "$http_status" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Supabase migration API request failed."
+            exit 1
+          fi
 
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0


### PR DESCRIPTION
Prints the migration API status and bounded response body so a failed target migration can be diagnosed without exposing credentials.