### PR TITLE
fix: repair async reporting refresh

### DIFF
--- a/.github/workflows/async-job-worker.yml
+++ b/.github/workflows/async-job-worker.yml
@@ -46,13 +46,19 @@ jobs:
           ITX_JOB_WORKER_SECRET: ${{ secrets.ITX_JOB_WORKER_SECRET }}
         run: |
           set -euo pipefail
-          curl -fsS \
+          RESPONSE="$(curl -fsS \
             -X POST "https://mlaspkufocikfcbjgpof.supabase.co/functions/v1/job-worker" \
             -H "Origin: https://itemtraxx.com" \
             -H "Authorization: Bearer ${ITX_JOB_WORKER_SECRET}" \
             -H "Content-Type: application/json" \
-            --data '{"limit": 30, "run_reporting_refresh": true}' \
-            | head -c 500
+            --data '{"limit": 30, "run_reporting_refresh": true}')"
+          printf '%s\n' "$RESPONSE" | cut -c1-500
+          if ! printf '%s' "$RESPONSE" | jq -e \
+            '.ok == true and (.data.failed // 0) == 0 and .data.reporting_refreshed == true' \
+            >/dev/null; then
+            echo "Async Job Worker reported a failed or incomplete reporting refresh."
+            exit 1
+          fi
 
   slack-notify-finish:
     needs:

--- a/.github/workflows/deploy-supabase-target.yml
+++ b/.github/workflows/deploy-supabase-target.yml
@@ -1,0 +1,92 @@
+name: Deploy Supabase Target
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Supabase target to migrate and deploy
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+        default: staging
+
+concurrency:
+  group: deploy-supabase-target-${{ inputs.target }}
+  cancel-in-progress: false
+
+jobs:
+  migrate-and-deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Resolve target
+        id: target
+        env:
+          TARGET: ${{ inputs.target }}
+        run: |
+          set -euo pipefail
+          case "$TARGET" in
+            staging)
+              project_ref="nwuhjxicaopkmqydjlas"
+              ;;
+            production)
+              project_ref="mlaspkufocikfcbjgpof"
+              ;;
+            *)
+              echo "Unsupported Supabase target: $TARGET" >&2
+              exit 1
+              ;;
+          esac
+          echo "project_ref=$project_ref" >> "$GITHUB_OUTPUT"
+          echo "Deploying checked-in migration and job-worker to $TARGET."
+
+      - name: Apply reporting refresh migration
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF: ${{ steps.target.outputs.project_ref }}
+          MIGRATION_PATH: supabase/migrations/20260814010000_fix_reporting_refresh_rpc.sql
+          MIGRATION_NAME: 20260814010000_fix_reporting_refresh_rpc
+        run: |
+          set -euo pipefail
+          test -s "$MIGRATION_PATH"
+          payload="$(jq -n \
+            --rawfile query "$MIGRATION_PATH" \
+            --arg name "$MIGRATION_NAME" \
+            '{query: $query, name: $name}')"
+          response="$(curl --fail-with-body -sS \
+            -X POST "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/database/migrations" \
+            -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data "$payload")"
+          printf '%s\n' "$response" | cut -c1-1000
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: 24.15.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Deploy job-worker
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF: ${{ steps.target.outputs.project_ref }}
+        run: python3 ./scripts/deploy-supabase-functions.py --project-ref "$SUPABASE_PROJECT_REF" job-worker

--- a/.github/workflows/deploy-supabase-target.yml
+++ b/.github/workflows/deploy-supabase-target.yml
@@ -64,12 +64,21 @@ jobs:
             --rawfile query "$MIGRATION_PATH" \
             --arg name "$MIGRATION_NAME" \
             '{query: $query, name: $name}')"
-          response="$(curl --fail-with-body -sS \
+          response_file="$(mktemp)"
+          trap 'rm -f "$response_file"' EXIT
+          http_status="$(curl -sS \
             -X POST "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_REF}/database/migrations" \
             -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
             -H "Content-Type: application/json" \
-            --data "$payload")"
-          printf '%s\n' "$response" | cut -c1-1000
+            --data "$payload" \
+            -o "$response_file" \
+            -w '%{http_code}' || true)"
+          printf 'Supabase migration API response (HTTP %s):\n' "$http_status"
+          cut -c1-2000 "$response_file"
+          if [[ ! "$http_status" =~ ^2[0-9][0-9]$ ]]; then
+            echo "Supabase migration API request failed."
+            exit 1
+          fi
 
       - name: Setup Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/supabase/functions/job-worker/index.ts
+++ b/supabase/functions/job-worker/index.ts
@@ -7,6 +7,7 @@ import { isKillSwitchWriteBlocked } from "../_shared/killSwitch.ts";
 import { getRequestId, logError, logInfo } from "../_shared/observability.ts";
 import { isAllowedOrigin, parseAllowedOrigins } from "../_shared/cors.ts";
 import { readJsonBody } from "../_shared/requestBody.ts";
+import { rpcErrorToError, throwOnRpcError } from "./reportingRefresh.ts";
 import {
   asRecord,
   optionalInteger,
@@ -1073,7 +1074,10 @@ serve(async (req) => {
             supportSlackWebhookUrl || undefined,
           );
         } else if (job.job_type === "refresh_reporting_views") {
-          await adminClient.rpc("refresh_super_reporting_views");
+          const { error: refreshError } = await adminClient.rpc(
+            "refresh_super_reporting_views",
+          );
+          throwOnRpcError("refresh_super_reporting_views", refreshError);
         }
 
         const { error: completeError } = await adminClient
@@ -1116,6 +1120,15 @@ serve(async (req) => {
       const { error: refreshError } = await adminClient.rpc("refresh_super_reporting_views");
       if (refreshError) {
         failed += 1;
+        const normalizedError = rpcErrorToError(
+          "refresh_super_reporting_views",
+          refreshError,
+        );
+        logError(
+          "job-worker reporting refresh failed",
+          requestId,
+          normalizedError ?? refreshError,
+        );
       } else {
         reportingRefreshed = true;
       }

--- a/supabase/functions/job-worker/reportingRefresh.ts
+++ b/supabase/functions/job-worker/reportingRefresh.ts
@@ -1,0 +1,25 @@
+type RpcErrorLike = {
+  code?: string | null;
+  message?: string | null;
+};
+
+export const rpcErrorToError = (
+  operation: string,
+  error: RpcErrorLike | null | undefined,
+): Error | null => {
+  if (!error) return null;
+
+  const code = error.code?.trim();
+  const message = error.message?.trim() || "Unknown database error";
+  return new Error(
+    `${operation} failed${code ? ` (${code})` : ""}: ${message}`,
+  );
+};
+
+export const throwOnRpcError = (
+  operation: string,
+  error: RpcErrorLike | null | undefined,
+): void => {
+  const normalizedError = rpcErrorToError(operation, error);
+  if (normalizedError) throw normalizedError;
+};

--- a/supabase/functions/job-worker/reportingRefresh_test.ts
+++ b/supabase/functions/job-worker/reportingRefresh_test.ts
@@ -1,0 +1,34 @@
+import { rpcErrorToError, throwOnRpcError } from "./reportingRefresh.ts";
+
+const assert = (condition: boolean, message: string) => {
+  if (!condition) throw new Error(message);
+};
+
+Deno.test("reporting RPC errors become actionable worker errors", () => {
+  try {
+    throwOnRpcError("refresh_super_reporting_views", {
+      code: "42P01",
+      message:
+        'relation "public.super_reporting_tenant_metrics" does not exist',
+    });
+  } catch (error) {
+    assert(error instanceof Error, "expected an Error instance");
+    if (!(error instanceof Error)) return;
+    assert(
+      error.message ===
+        'refresh_super_reporting_views failed (42P01): relation "public.super_reporting_tenant_metrics" does not exist',
+      "expected the database code and message to be preserved",
+    );
+    return;
+  }
+
+  throw new Error("expected the reporting RPC error to throw");
+});
+
+Deno.test("successful reporting RPCs do not throw", () => {
+  throwOnRpcError("refresh_super_reporting_views", null);
+  assert(
+    rpcErrorToError("refresh_super_reporting_views", null) === null,
+    "successful RPCs should not create an error",
+  );
+});

--- a/supabase/migrations/20260814010000_fix_reporting_refresh_rpc.sql
+++ b/supabase/migrations/20260814010000_fix_reporting_refresh_rpc.sql
@@ -1,0 +1,22 @@
+-- Keep the reporting refresh RPC aligned with the workspace reporting view.
+-- The workspace migration removed the legacy tenant-named materialized view,
+-- but the pre-migration function body survived because PL/pgSQL dependencies
+-- are resolved when the function runs.
+
+begin;
+
+create or replace function public.refresh_super_reporting_views()
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  refresh materialized view public.super_reporting_workspace_metrics;
+end;
+$$;
+
+revoke all on function public.refresh_super_reporting_views() from public, anon, authenticated;
+grant execute on function public.refresh_super_reporting_views() to service_role;
+
+commit;

--- a/supabase/tests/workspace_model_assertions.sql
+++ b/supabase/tests/workspace_model_assertions.sql
@@ -14,6 +14,22 @@ begin
   if exists(select 1 from public.profiles where role in ('tenant_admin','tenant_user','district_admin')) then
     raise exception 'legacy roles remain';
   end if;
+  if to_regclass('public.super_reporting_tenant_metrics') is not null
+     or to_regclass('public.super_reporting_workspace_metrics') is null then
+    raise exception 'reporting materialized view names are not aligned with the workspace model';
+  end if;
+  if to_regprocedure('public.refresh_super_reporting_views()') is null
+     or position(
+       'super_reporting_workspace_metrics'
+       in lower(pg_get_functiondef(to_regprocedure('public.refresh_super_reporting_views()')))
+     ) = 0 then
+    raise exception 'reporting refresh RPC is not aligned with the workspace materialized view';
+  end if;
+  if has_function_privilege('anon', 'public.refresh_super_reporting_views()', 'EXECUTE')
+     or has_function_privilege('authenticated', 'public.refresh_super_reporting_views()', 'EXECUTE')
+     or not has_function_privilege('service_role', 'public.refresh_super_reporting_views()', 'EXECUTE') then
+    raise exception 'reporting refresh RPC grants are not service-role-only';
+  end if;
   if (select role from public.profiles where id='30000000-0000-0000-0000-000000000001') <> 'workspace_admin'
      or (select role from public.profiles where id='30000000-0000-0000-0000-000000000002') <> 'tenant_account' then
     raise exception 'legacy roles were not mapped';


### PR DESCRIPTION
Fixes the async job worker reporting refresh failure by:

- adding migration 20260814010000_fix_reporting_refresh_rpc to point the RPC at super_reporting_workspace_metrics
- surfacing queued RPC errors instead of marking failed jobs complete
- reporting direct refresh failures in the worker response/logs
- adding migration-backed SQL assertions and worker tests
- making the scheduled worker fail on incomplete refresh responses

Production migration and job-worker deployment were verified live. Staging function deployment is complete; staging database migration is pending its database credential.