### PR TITLE
fix: enforce active workspace on borrower lookup

### DIFF
--- a/supabase/functions/_shared/workspaceAccess.ts
+++ b/supabase/functions/_shared/workspaceAccess.ts
@@ -1,0 +1,26 @@
+export type WorkspaceStatusRow = {
+  status?: string | null;
+} | null | undefined;
+
+export type WorkspaceAccessResult =
+  | { allowed: true; reason: "active" }
+  | { allowed: false; reason: "disabled" | "unavailable" };
+
+/**
+ * Resolve the workspace authorization boundary without treating missing or
+ * unreadable status data as an active workspace.
+ */
+export const resolveWorkspaceAccess = (
+  row: WorkspaceStatusRow,
+  error: unknown,
+): WorkspaceAccessResult => {
+  if (error || !row || row.status == null) {
+    return { allowed: false, reason: "unavailable" };
+  }
+
+  if (row.status !== "active") {
+    return { allowed: false, reason: "disabled" };
+  }
+
+  return { allowed: true, reason: "active" };
+};

--- a/supabase/functions/_shared/workspaceAccess_test.ts
+++ b/supabase/functions/_shared/workspaceAccess_test.ts
@@ -1,0 +1,41 @@
+import { resolveWorkspaceAccess } from "./workspaceAccess.ts";
+
+const assert = (condition: boolean, message: string) => {
+  if (!condition) throw new Error(message);
+};
+
+Deno.test("workspace access allows an explicitly active workspace", () => {
+  const result = resolveWorkspaceAccess({ status: "active" }, null);
+  assert(result.allowed && result.reason === "active", "expected active access");
+});
+
+Deno.test("workspace access denies suspended and unknown statuses", () => {
+  const suspended = resolveWorkspaceAccess({ status: "suspended" }, null);
+  assert(
+    !suspended.allowed && suspended.reason === "disabled",
+    "expected suspended workspace denial",
+  );
+
+  const unknown = resolveWorkspaceAccess({ status: "archived" }, null);
+  assert(
+    !unknown.allowed && unknown.reason === "disabled",
+    "expected non-active workspace denial",
+  );
+});
+
+Deno.test("workspace access fails closed when status cannot be trusted", () => {
+  const missing = resolveWorkspaceAccess(null, null);
+  assert(
+    !missing.allowed && missing.reason === "unavailable",
+    "expected missing status to fail closed",
+  );
+
+  const queryError = resolveWorkspaceAccess(
+    { status: "active" },
+    new Error("workspace query failed"),
+  );
+  assert(
+    !queryError.allowed && queryError.reason === "unavailable",
+    "expected query errors to fail closed",
+  );
+});

--- a/supabase/functions/checkout-borrower-lookup/index.ts
+++ b/supabase/functions/checkout-borrower-lookup/index.ts
@@ -5,6 +5,7 @@ import { resolveRateLimitResult } from "../_shared/preloginGuards.ts";
 import { readJsonBody } from "../_shared/requestBody.ts";
 import { requireTrustedEdgeIngress } from "../_shared/trustedIngress.ts";
 import { validateAccountDeviceSession } from "../_shared/accountSessions.ts";
+import { resolveWorkspaceAccess } from "../_shared/workspaceAccess.ts";
 import {
   requireText,
   BORROWER_ID_PATTERN,
@@ -80,6 +81,22 @@ serve(async (req) => {
       !["tenant_account", "workspace_admin"].includes(profile.role)
     ) {
       return jsonResponse(403, { error: "Access denied" });
+    }
+
+    const { data: workspaceStatusRow, error: workspaceStatusError } =
+      await userClient
+        .from("workspaces")
+        .select("status")
+        .eq("id", profile.workspace_id)
+        .single();
+    const workspaceAccess = resolveWorkspaceAccess(
+      workspaceStatusRow,
+      workspaceStatusError,
+    );
+    if (!workspaceAccess.allowed) {
+      return workspaceAccess.reason === "disabled"
+        ? jsonResponse(403, { error: "Workspace disabled" })
+        : jsonResponse(503, { error: "Workspace status unavailable" });
     }
 
     const { data: rateLimit, error: rateLimitError } = await userClient.rpc(


### PR DESCRIPTION
This pull request introduces a new utility for handling workspace access control, integrates it into the borrower lookup flow, and adds comprehensive tests to ensure correct behavior. The main goal is to ensure that only users in active workspaces can proceed, and that missing or erroneous status data results in access denial.

**Workspace access control:**

* Added a new function `resolveWorkspaceAccess` in `workspaceAccess.ts` to determine if a workspace is active, disabled, or unavailable, handling missing or unreadable status data securely.
* Integrated `resolveWorkspaceAccess` into the borrower lookup flow in `checkout-borrower-lookup/index.ts`, ensuring requests from disabled or unavailable workspaces are denied with appropriate status codes. [[1]](diffhunk://#diff-d0cf909ecf9bd0a13aed9a37832b3db9351dcacbe6caf6db2457b4e3e85b32f1R8) [[2]](diffhunk://#diff-d0cf909ecf9bd0a13aed9a37832b3db9351dcacbe6caf6db2457b4e3e85b32f1R86-R101)

**Testing:**

* Added a dedicated test suite in `workspaceAccess_test.ts` to verify correct handling of active, disabled, and unavailable workspace states.