### PR TITLE
fix(db): align reporting item count name

### DIFF
--- a/supabase/migrations/20260816150000_align_reporting_item_total.sql
+++ b/supabase/migrations/20260816150000_align_reporting_item_total.sql
@@ -1,0 +1,29 @@
+-- Keep the Super Admin reporting contract aligned with the item-based schema.
+-- The workspace-model migration created this output as gear_total before the
+-- physical gear -> items rename. Renaming the materialized-view column avoids
+-- changing the Edge Function and frontend contract or touching stored data.
+do $$
+begin
+  if to_regclass('public.super_reporting_workspace_metrics') is null then
+    return;
+  end if;
+
+  if exists (
+       select 1
+       from pg_attribute
+       where attrelid = 'public.super_reporting_workspace_metrics'::regclass
+         and attname = 'gear_total'
+         and not attisdropped
+     )
+     and not exists (
+       select 1
+       from pg_attribute
+       where attrelid = 'public.super_reporting_workspace_metrics'::regclass
+         and attname = 'item_total'
+         and not attisdropped
+     ) then
+    alter materialized view public.super_reporting_workspace_metrics
+      rename column gear_total to item_total;
+  end if;
+end
+$$;

--- a/supabase/tests/workspace_model_assertions.sql
+++ b/supabase/tests/workspace_model_assertions.sql
@@ -18,6 +18,22 @@ begin
      or to_regclass('public.super_reporting_workspace_metrics') is null then
     raise exception 'reporting materialized view names are not aligned with the workspace model';
   end if;
+  if not exists (
+       select 1
+       from pg_attribute
+       where attrelid = 'public.super_reporting_workspace_metrics'::regclass
+         and attname = 'item_total'
+         and not attisdropped
+     )
+     or exists (
+       select 1
+       from pg_attribute
+       where attrelid = 'public.super_reporting_workspace_metrics'::regclass
+         and attname = 'gear_total'
+         and not attisdropped
+     ) then
+    raise exception 'reporting materialized view item count column is not item_total';
+  end if;
   if to_regprocedure('public.refresh_super_reporting_views()') is null
      or position(
        'super_reporting_workspace_metrics'


### PR DESCRIPTION
Rename the materialized-view output to item_total so the Super Admin
reporting query matches the item-based schema, and assert the contract
in workspace tests.