### PR TITLE
Update package.json to allow install scripts and bump dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: ${{ !cancelled() }}
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           languages: actions,javascript-typescript
           build-mode: none
@@ -259,7 +259,7 @@ jobs:
 
       - name: Perform CodeQL Analysis
         if: ${{ !cancelled() }}
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
 
       # Keep failure alerting inside the validation job so a normal run does
       # not publish a separate skipped incident-notification check.

--- a/package.json
+++ b/package.json
@@ -95,5 +95,13 @@
     "ip-address": "^10.3.1",
     "workerd": "1.20260811.1",
     "@noble/curves": "2.3.0"
+  },
+  "allowScripts": {
+    "core-js@3.50.0": true,
+    "esbuild@0.28.1": true,
+    "fsevents@2.3.2": true,
+    "fsevents@2.3.3": true,
+    "libxmljs2@0.37.0": true,
+    "workerd@1.20260811.1": true
   }
 }


### PR DESCRIPTION
This pull request updates github-actions group with 2 updates and updates the `package.json` file to explicitly allow install scripts for several dependencies; Aimed to fix issue where vercel build logs would throw warnings for those deps:

Dependency installation configuration:

* Added an `allowScripts` section to `package.json` to permit install
scripts for `core-js@3.50.0`, `esbuild@0.28.1`, `fsevents@2.3.2`,
`fsevents@2.3.3`, `libxmljs2@0.37.0`, and `workerd@1.20260811.1`.

Warning build log lines:
21:12:51.528 npm warn allow-scripts 4 packages have install scripts not yet covered by allowScripts:
21:12:51.528 npm warn allow-scripts core-js@3.50.0 (postinstall: node -e "try{require('./postinstall')}catch(e){}")
21:12:51.528 npm warn allow-scripts esbuild@0.28.1 (postinstall: node install.js)
21:12:51.528 npm warn allow-scripts libxmljs2@0.37.0 (install: node-gyp rebuild)
21:12:51.528 npm warn allow-scripts workerd@1.20260811.1 (postinstall: node install.js)
21:12:51.528 npm warn allow-scripts
21:12:51.528 npm warn allow-scripts Run `npm approve-scripts --allow-scripts-pending` to review, or `npm approve-scripts <pkg>` to allow. 

