### PR TITLE
promote: restore online checkout return flow to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,7 @@ VITE_PRIVACY_URL=
 # Local development example:
 # ITX_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:5174
 # Shared environment example:
-# ITX_ALLOWED_ORIGINS=https://itemtraxx.com,https://www.itemtraxx.com,https://status.itemtraxx.com,https://internal.itemtraxx.com,https://app.itemtraxx.com,https://preview.itemtraxx.com,https://staging.itemtraxx.com
+# ITX_ALLOWED_ORIGINS=https://itemtraxx.com,https://www.itemtraxx.com,https://status.itemtraxx.com,https://internal.itemtraxx.com,https://app.itemtraxx.com,https://preview.itemtraxx.com,https://staging.itemtraxx.com,https://itxdemo.app.itemtraxx.com
 ITX_ALLOWED_ORIGINS=
 # VITE_TENANT_LOGIN_FUNCTION=tenant-login
 # VITE_LOGIN_NOTIFY_FUNCTION=login-notify

--- a/cloudflare/edge-proxy/src/constants.ts
+++ b/cloudflare/edge-proxy/src/constants.ts
@@ -34,4 +34,5 @@ export const DEFAULT_ALLOWED_ORIGINS = [
   "https://app.itemtraxx.com",
   "https://preview.itemtraxx.com",
   "https://staging.itemtraxx.com",
+  "https://itxdemo.app.itemtraxx.com",
 ];

--- a/cloudflare/edge-proxy/src/cors_test.ts
+++ b/cloudflare/edge-proxy/src/cors_test.ts
@@ -118,6 +118,7 @@ Deno.test("the default production allowlist keeps required surfaces and excludes
     "https://status.itemtraxx.com",
     "https://preview.itemtraxx.com",
     "https://staging.itemtraxx.com",
+    "https://itxdemo.app.itemtraxx.com",
   ]) {
     assert(
       DEFAULT_ALLOWED_ORIGINS.includes(origin),
@@ -125,7 +126,6 @@ Deno.test("the default production allowlist keeps required surfaces and excludes
     );
   }
   for (const origin of [
-    "https://itxdemo.app.itemtraxx.com",
     "https://pentest.app.itemtraxx.com",
     "https://testdist.app.itemtraxx.com",
     "https://dennis-dev.itemtraxx.com",

--- a/cloudflare/edge-proxy/src/index_test.ts
+++ b/cloudflare/edge-proxy/src/index_test.ts
@@ -193,6 +193,32 @@ Deno.test("edge proxy CORS requires exact configured origins", async () => {
   }
 });
 
+Deno.test("edge proxy CORS allows the explicitly configured demo workspace", async () => {
+  const demoOrigin = "https://itxdemo.app.itemtraxx.com";
+  const response = await worker.fetch(
+    new Request("https://edge.itemtraxx.com/auth/session/me", {
+      method: "OPTIONS",
+      headers: {
+        origin: demoOrigin,
+        "access-control-request-method": "GET",
+        "access-control-request-headers": "content-type",
+      },
+    }),
+    {
+      SUPABASE_URL: "https://example.supabase.co",
+      SUPABASE_ANON_KEY: "anon-key",
+    },
+    executionContext,
+  );
+
+  if (
+    response.status !== 200 ||
+    response.headers.get("Access-Control-Allow-Origin") !== demoOrigin
+  ) {
+    throw new Error("Expected the demo workspace origin to be allowed");
+  }
+});
+
 Deno.test("edge proxy CORS does not expand wildcard origin patterns", async () => {
   const response = await worker.fetch(
     new Request("https://edge.itemtraxx.com/functions/v1/system-status", {

--- a/cloudflare/edge-proxy/wrangler.toml
+++ b/cloudflare/edge-proxy/wrangler.toml
@@ -19,9 +19,9 @@ enabled = true
   persist = true
 
 [vars]
-# Production and explicitly routed promotion surfaces only. Workspace app
-# origins remain covered by the exact HTTPS *.app.itemtraxx.com rule in code.
-ALLOWED_ORIGINS = "https://itemtraxx.com,https://www.itemtraxx.com,https://status.itemtraxx.com,https://internal.itemtraxx.com,https://app.itemtraxx.com,https://preview.itemtraxx.com,https://staging.itemtraxx.com"
+# Production and explicitly routed promotion surfaces only. The demo workspace
+# is explicitly allowed; other reserved/test workspace slugs remain denied.
+ALLOWED_ORIGINS = "https://itemtraxx.com,https://www.itemtraxx.com,https://status.itemtraxx.com,https://internal.itemtraxx.com,https://app.itemtraxx.com,https://preview.itemtraxx.com,https://staging.itemtraxx.com,https://itxdemo.app.itemtraxx.com"
 TRUST_LOCAL_ORIGINS = "false"
 SESSION_COOKIE_DOMAIN = ".itemtraxx.com"
 SESSION_COOKIE_SAMESITE = "lax"

--- a/src/services/checkoutService.spec.ts
+++ b/src/services/checkoutService.spec.ts
@@ -39,6 +39,7 @@ vi.mock("../store/authState", () => ({
   getAuthState: vi.fn(),
 }));
 vi.mock("./offlineConnectionState", () => ({
+  isServerUnreachableStatus: (status: number) => status === 0,
   markItemTraxxServerConfirmed: vi.fn(),
   markItemTraxxServerUnreachable: vi.fn(),
 }));
@@ -150,7 +151,7 @@ describe("submitCheckoutReturn", () => {
     await expect(submitCheckoutReturn(payload)).resolves.toEqual({ buffered: false, queuedCount: 0 });
   });
 
-  it("treats a 429 as queueable: retries online, then surfaces the offline-unavailable error without an offline context", async () => {
+  it("treats a 429 as queueable without labeling the reachable server offline", async () => {
     setOnline(true);
     mockedInvoke.mockResolvedValue(failResponse(429) as never);
 
@@ -158,7 +159,7 @@ describe("submitCheckoutReturn", () => {
     // with no offline context to buffer into, surfaces the generic offline-unavailable
     // error rather than the underlying "rate limit exceeded" message.
     await expect(submitCheckoutReturn(payload)).rejects.toThrow(/offline checkout is unavailable/i);
-    expect(mockedMarkUnreachable).toHaveBeenCalled();
+    expect(mockedMarkUnreachable).not.toHaveBeenCalled();
     expect(mockedInvoke).toHaveBeenCalledTimes(2);
   });
 
@@ -215,6 +216,7 @@ describe("submitCheckoutReturn", () => {
     expect(mockedQueueOfflineOperation).toHaveBeenCalledWith(
       expect.objectContaining({ operationId: "op-mock", borrower: null, items: [] })
     );
+    expect(mockedMarkUnreachable).not.toHaveBeenCalled();
   });
 
   it("buffers immediately without retrying when offline", async () => {
@@ -419,14 +421,14 @@ describe("fetchBorrowerByBorrowerId", () => {
     expect(mockedMarkConfirmed).toHaveBeenCalled();
   });
 
-  it("falls back offline on a 5xx/429/0 status without throwing when an offline match exists", async () => {
+  it("falls back to the offline pack on a server failure without labeling the reachable server offline", async () => {
     setOnline(true);
     mockedInvoke.mockResolvedValue(failResponse(503) as never);
     mockedFindOfflineBorrower.mockResolvedValue({ id: "b-1", username: "jdoe", borrower_id: "1234AB" });
 
     const result = await fetchBorrowerByBorrowerId("1234AB");
     expect(result).toMatchObject({ id: "b-1" });
-    expect(mockedMarkUnreachable).toHaveBeenCalled();
+    expect(mockedMarkUnreachable).not.toHaveBeenCalled();
   });
 
   it("throws a mapped error when the status is a retryable failure but there is no offline match", async () => {

--- a/src/services/checkoutService.ts
+++ b/src/services/checkoutService.ts
@@ -24,7 +24,11 @@ import {
   type OfflinePackItem,
 } from "./offlineCheckoutWorkflow";
 import { getAuthState } from "../store/authState";
-import { markItemTraxxServerConfirmed, markItemTraxxServerUnreachable } from "./offlineConnectionState";
+import {
+  isServerUnreachableStatus,
+  markItemTraxxServerConfirmed,
+  markItemTraxxServerUnreachable,
+} from "./offlineConnectionState";
 
 export { consumeCheckoutOfflineWarning } from "./offlineCheckoutQueue";
 export type { CheckoutReturnPayload } from "./offlineCheckoutQueue";
@@ -75,7 +79,7 @@ const isQueueableFailure = (error: unknown) => {
 
 const recordCheckoutResponse = (ok: boolean, status: number) => {
   if (ok) markItemTraxxServerConfirmed();
-  else if (status === 0 || status === 429 || status >= 500) markItemTraxxServerUnreachable();
+  else if (isServerUnreachableStatus(status)) markItemTraxxServerUnreachable();
 };
 
 const isLookupConnectivityFailure = (error: unknown) => {
@@ -304,7 +308,7 @@ export const fetchBorrowerByBorrowerId = async (borrowerId: string) => {
   }
 
   if (result.status === 0 || result.status === 429 || result.status >= 500) {
-    markItemTraxxServerUnreachable();
+    if (isServerUnreachableStatus(result.status)) markItemTraxxServerUnreachable();
     const offline = await findOfflineBorrower(getOfflineScope(), borrowerId);
     if (offline) return offline as BorrowerSummary;
   } else if (result.ok) {

--- a/src/services/offlineCheckoutWorkflow.ts
+++ b/src/services/offlineCheckoutWorkflow.ts
@@ -1,7 +1,11 @@
 import { invokeEdgeFunction } from "./edgeFunctionClient";
 import { getOrCreateDeviceSession } from "../utils/deviceSession";
 import { getAuthState } from "../store/authState";
-import { markItemTraxxServerConfirmed, markItemTraxxServerUnreachable } from "./offlineConnectionState";
+import {
+  isServerUnreachableStatus,
+  markItemTraxxServerConfirmed,
+  markItemTraxxServerUnreachable,
+} from "./offlineConnectionState";
 
 export type OfflinePackBorrower = {
   id: string;
@@ -114,7 +118,7 @@ const isRetryableWorkflowStatus = (status: number) => status === 0 || status ===
 
 const recordWorkflowResponse = (ok: boolean, status: number) => {
   if (ok) markItemTraxxServerConfirmed();
-  else if (isRetryableWorkflowStatus(status)) markItemTraxxServerUnreachable();
+  else if (isServerUnreachableStatus(status)) markItemTraxxServerUnreachable();
 };
 
 const createId = () =>

--- a/src/services/offlineConnectionState.spec.ts
+++ b/src/services/offlineConnectionState.spec.ts
@@ -3,12 +3,21 @@ import {
   acknowledgeOfflineWarning,
   clearOfflineConnectionState,
   getOfflineWarningThreshold,
+  isServerUnreachableStatus,
   markItemTraxxServerConfirmed,
   markItemTraxxServerUnreachable,
   readOfflineConnectionState,
 } from "./offlineConnectionState";
 
 const STORAGE_KEY = "itemtraxx:offline-connection:v1";
+
+describe("isServerUnreachableStatus", () => {
+  it("only treats a fetch-level status 0 as unreachable", () => {
+    expect(isServerUnreachableStatus(0)).toBe(true);
+    expect(isServerUnreachableStatus(429)).toBe(false);
+    expect(isServerUnreachableStatus(500)).toBe(false);
+  });
+});
 
 // Node's own experimental global `localStorage` (gated behind --localstorage-file,
 // see the "ExperimentalWarning: localStorage is not available" log) shadows jsdom's

--- a/src/services/offlineConnectionState.ts
+++ b/src/services/offlineConnectionState.ts
@@ -6,6 +6,11 @@ export type OfflineConnectionState = {
 
 const STORAGE_KEY = "itemtraxx:offline-connection:v1";
 
+// An HTTP response proves that ItemTraxx was reachable. Only fetch-level
+// failures (status 0) should switch the UI into the offline workflow; server
+// application errors such as 4xx/5xx must remain visible as request failures.
+export const isServerUnreachableStatus = (status: number) => status === 0;
+
 const emptyState = (): OfflineConnectionState => ({
   last_confirmed_at: null,
   unreachable_since: null,
@@ -62,4 +67,3 @@ export const clearOfflineConnectionState = () => {
   window.localStorage.removeItem(STORAGE_KEY);
   window.dispatchEvent(new CustomEvent("itemtraxx:offline-connection-changed"));
 };
-

--- a/supabase/functions/_shared/cors_test.ts
+++ b/supabase/functions/_shared/cors_test.ts
@@ -18,6 +18,8 @@ Deno.test("isAllowedOrigin requires exact configured origins", () => {
 
   assert(isAllowedOrigin("https://app.itemtraxx.com", allowedOrigins));
   assert(isAllowedOrigin("https://staging.itemtraxx.com", allowedOrigins));
+  const demoOrigin = parseAllowedOrigins("https://itxdemo.app.itemtraxx.com");
+  assert(isAllowedOrigin("https://itxdemo.app.itemtraxx.com", demoOrigin));
 });
 
 Deno.test("isAllowedOrigin does not expand wildcard origin patterns", () => {

--- a/supabase/migrations/20260822150000_fix_checkout_return_operation_id_ambiguity.sql
+++ b/supabase/migrations/20260822150000_fix_checkout_return_operation_id_ambiguity.sql
@@ -1,0 +1,205 @@
+begin;
+
+-- The original atomic checkout function declared a local operation_id variable
+-- with the same name as public.item_logs.operation_id. PostgreSQL cannot resolve
+-- the unqualified references in the idempotency query, so every online
+-- checkout/return reached the RPC and then failed with an ambiguous-column
+-- error. Keep the function contract stable and use a distinct local name.
+create or replace function public.apply_checkout_return_item(
+  p_workspace_id uuid,
+  p_profile_id uuid,
+  p_item_id uuid,
+  p_operation_id text,
+  p_action_type text,
+  p_borrower_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  actor_role text;
+  requested_action text := lower(btrim(coalesce(p_action_type, '')));
+  v_operation_id text := btrim(coalesce(p_operation_id, ''));
+  item_row public.items%rowtype;
+  resolved_action text;
+  target_status text;
+  target_borrower uuid;
+  log_borrower uuid;
+  log_operation_id text;
+  has_existing_operation boolean;
+begin
+  if p_workspace_id is null
+     or p_profile_id is null
+     or p_item_id is null
+     or v_operation_id = ''
+     or char_length(v_operation_id) > 128
+     or requested_action not in ('checkout', 'return', 'auto', 'admin_return', 'quick_return') then
+    raise exception 'Invalid checkout/return payload' using errcode = '22023';
+  end if;
+
+  select profile.role into actor_role
+  from public.profiles profile
+  join public.workspaces workspace on workspace.id = profile.workspace_id
+  where profile.id = p_profile_id
+    and profile.workspace_id = p_workspace_id
+    and profile.role in ('tenant_account', 'workspace_admin')
+    and profile.is_active
+    and profile.deleted_at is null
+    and workspace.status = 'active';
+
+  if actor_role is null then
+    raise exception 'Checkout/return actor is not active' using errcode = '42501';
+  end if;
+
+  if requested_action in ('admin_return', 'quick_return')
+     and actor_role <> 'workspace_admin' then
+    raise exception 'Administrative return requires a Workspace Admin' using errcode = '42501';
+  end if;
+
+  select item.* into item_row
+  from public.items item
+  where item.id = p_item_id
+    and item.workspace_id = p_workspace_id
+    and item.deleted_at is null
+  for update;
+
+  if not found then
+    return jsonb_build_object('status', 'skipped', 'reason', 'item_unavailable');
+  end if;
+
+  if actor_role = 'tenant_account'
+     and item_row.access_mode <> 'all'
+     and not exists (
+       select 1
+       from public.item_access_grants grant_row
+       where grant_row.item_id = p_item_id
+         and grant_row.profile_id = p_profile_id
+     ) then
+    return jsonb_build_object('status', 'skipped', 'reason', 'item_unavailable');
+  end if;
+
+  if requested_action in ('checkout', 'return', 'auto') then
+    if p_borrower_id is null or not exists (
+      select 1
+      from public.borrowers borrower
+      where borrower.id = p_borrower_id
+        and borrower.workspace_id = p_workspace_id
+        and borrower.deleted_at is null
+        and (
+          actor_role = 'workspace_admin'
+          or borrower.access_mode = 'all'
+          or exists (
+            select 1
+            from public.borrower_access_grants grant_row
+            where grant_row.borrower_id = borrower.id
+              and grant_row.profile_id = p_profile_id
+          )
+        )
+    ) then
+      return jsonb_build_object('status', 'skipped', 'reason', 'borrower_unavailable');
+    end if;
+  end if;
+
+  -- Check both normal action log keys before inspecting current state. This is
+  -- what makes a retried auto/checkout/return request idempotent even after the
+  -- first transaction has already changed the item state.
+  if requested_action in ('checkout', 'return', 'auto') then
+    select exists (
+      select 1
+      from public.item_logs item_log
+      where item_log.workspace_id = p_workspace_id
+        and item_log.item_id = p_item_id
+        and item_log.operation_id in (
+          v_operation_id || ':' || p_item_id::text || ':checkout',
+          v_operation_id || ':' || p_item_id::text || ':return'
+        )
+    ) into has_existing_operation;
+  else
+    select exists (
+      select 1
+      from public.item_logs item_log
+      where item_log.workspace_id = p_workspace_id
+        and item_log.item_id = p_item_id
+        and item_log.operation_id = v_operation_id || ':' || p_item_id::text || ':' || requested_action
+    ) into has_existing_operation;
+  end if;
+
+  if has_existing_operation then
+    return jsonb_build_object('status', 'idempotent');
+  end if;
+
+  if requested_action = 'auto' then
+    if lower(item_row.status) = 'available' and item_row.checked_out_by is null then
+      resolved_action := 'checkout';
+    elsif lower(item_row.status) = 'checked_out'
+      and item_row.checked_out_by is not distinct from p_borrower_id then
+      resolved_action := 'return';
+    else
+      return jsonb_build_object('status', 'skipped', 'reason', 'state_changed');
+    end if;
+  elsif requested_action = 'checkout' then
+    if lower(item_row.status) <> 'available' or item_row.checked_out_by is not null then
+      return jsonb_build_object('status', 'skipped', 'reason', 'state_changed');
+    end if;
+    resolved_action := 'checkout';
+  elsif requested_action = 'return' then
+    if lower(item_row.status) <> 'checked_out'
+       or item_row.checked_out_by is distinct from p_borrower_id then
+      return jsonb_build_object('status', 'skipped', 'reason', 'state_changed');
+    end if;
+    resolved_action := 'return';
+  else
+    if lower(item_row.status) <> 'checked_out' or item_row.checked_out_by is null then
+      return jsonb_build_object('status', 'skipped', 'reason', 'state_changed');
+    end if;
+    resolved_action := requested_action;
+  end if;
+
+  if resolved_action = 'checkout' then
+    target_status := 'checked_out';
+    target_borrower := p_borrower_id;
+    log_borrower := p_borrower_id;
+  else
+    target_status := 'available';
+    target_borrower := null;
+    log_borrower := coalesce(p_borrower_id, item_row.checked_out_by);
+  end if;
+
+  if log_borrower is null or not exists (
+    select 1
+    from public.borrowers borrower
+    where borrower.id = log_borrower
+      and borrower.workspace_id = p_workspace_id
+  ) then
+    raise exception 'Checkout/return log borrower is invalid' using errcode = '22023';
+  end if;
+
+  log_operation_id := v_operation_id || ':' || p_item_id::text || ':' || resolved_action;
+
+  update public.items
+  set status = target_status,
+      checked_out_by = target_borrower,
+      checked_out_at = case when target_status = 'checked_out' then now() else null end
+  where id = p_item_id;
+
+  insert into public.item_logs(
+    workspace_id, item_id, checked_out_by, action_type, performed_by, operation_id
+  ) values (
+    p_workspace_id, p_item_id, log_borrower, resolved_action, p_profile_id, log_operation_id
+  ) on conflict (workspace_id, item_id, action_type, operation_id) do nothing;
+
+  return jsonb_build_object(
+    'status', 'processed',
+    'action_type', resolved_action
+  );
+end;
+$$;
+
+revoke all on function public.apply_checkout_return_item(uuid,uuid,uuid,text,text,uuid)
+  from public, anon, authenticated;
+grant execute on function public.apply_checkout_return_item(uuid,uuid,uuid,text,text,uuid)
+  to service_role;
+
+commit;

--- a/supabase/tests/checkout_return_atomicity_assertions.sql
+++ b/supabase/tests/checkout_return_atomicity_assertions.sql
@@ -40,6 +40,10 @@ begin
      or position('actor_role <> ''workspace_admin''' in function_definition) = 0 then
     raise exception 'online checkout/return function is missing locking, audit, idempotency, or role checks';
   end if;
+  if position('  v_operation_id text :=' in function_definition) = 0
+     or position('  operation_id text :=' in function_definition) > 0 then
+    raise exception 'online checkout/return function must avoid ambiguous operation_id variable references';
+  end if;
 end $$;
 
 select 'online checkout/return atomicity assertions passed' as result;


### PR DESCRIPTION
Promote the validated checkout/return fix to production.

Promotion history:
- Source fix: b6b03f9
- staging merge: bbfbc196
- preview merge: c469a5aa

The production Supabase migration must be applied from main using the protected Deploy Supabase Target workflow after this promotion. Vercel production should deploy the resulting main SHA.