### PR TITLE
promote: staging to preview (offline cache sync)

### DIFF
--- a/src/components/OfflineWorkflowStatus.vue
+++ b/src/components/OfflineWorkflowStatus.vue
@@ -1,9 +1,17 @@
 <template>
-  <section v-if="isOffline" class="offline-workflow-status" aria-label="Offline checkout status">
-    <div>
+  <section v-if="showStatus" class="offline-workflow-status" aria-label="Offline checkout status">
+    <div class="offline-workflow-status-content">
       <strong>{{ statusTitle }}</strong>
       <span>{{ statusDetail }}</span>
     </div>
+    <button
+      type="button"
+      class="button-secondary offline-sync-button"
+      :disabled="syncInFlight"
+      @click="syncNow(true)"
+    >
+      {{ syncInFlight ? "Syncing…" : "Sync now" }}
+    </button>
   </section>
   <div v-if="message" class="toast" :class="{ 'toast-persist': messageKind === 'error' }" role="status" aria-live="polite">
     <div class="toast-title">{{ messageTitle }}</div>
@@ -13,6 +21,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onScopeDispose, ref } from "vue";
+import { syncCheckoutQueues, type CheckoutQueueSyncResult } from "../services/checkoutService";
 import {
   getOfflineWorkflowSummary,
   isOfflineSessionInitializingError,
@@ -27,8 +36,10 @@ const summary = ref<Summary>({ pack: null, packExpired: false, pendingCount: 0, 
 const connection = ref(readOfflineConnectionState());
 const message = ref("");
 const messageKind = ref<"success" | "error" | "info">("success");
+const syncInFlight = ref(false);
 let pollTimer: number | null = null;
 let refreshTimer: number | null = null;
+let syncTimer: number | null = null;
 let toastTimer: number | null = null;
 let offlineSafetyNoticeShown = false;
 let preparationNoticeShown = false;
@@ -44,12 +55,20 @@ const formatTime = (value: string | null | undefined) => {
 
 const statusTitle = computed(() => {
   if (connection.value.unreachable_since) return "Offline checkout active";
+  if (summary.value.syncingCount > 0) return "Syncing offline transactions";
+  if (summary.value.pendingCount > 0) return "Offline transactions pending";
+  if (summary.value.reviewCount > 0) return "Offline sync needs review";
   if (!summary.value.pack) return "Preparing offline checkout";
   if (summary.value.packExpired) return "Offline pack expired";
   return "Ready for offline use";
 });
 
-const isOffline = computed(() => !!connection.value.unreachable_since);
+const showStatus = computed(() =>
+  !!connection.value.unreachable_since ||
+  summary.value.pendingCount > 0 ||
+  summary.value.syncingCount > 0 ||
+  summary.value.reviewCount > 0,
+);
 const messageTitle = computed(() => {
   if (messageKind.value === "error") return "Offline setup needs attention";
   if (message.value.startsWith("Preparing")) return "Preparing for offline use";
@@ -62,6 +81,8 @@ const statusDetail = computed(() => {
   const review = summary.value.reviewCount;
   const counts = `${pending} pending${review ? ` · ${review} need${review === 1 ? "s" : ""} review` : ""}`;
   if (connection.value.unreachable_since) return `Last connected ${formatTime(connection.value.last_confirmed_at)} · ${counts}`;
+  if (summary.value.syncingCount > 0) return `Connected · syncing ${summary.value.syncingCount} transaction${summary.value.syncingCount === 1 ? "" : "s"}`;
+  if (pending > 0 || review > 0) return `Connected · ${counts}`;
   if (!summary.value.pack) return "Setting up this device for an outage.";
   return `Updated ${formatTime(summary.value.pack.prepared_at)} · ${counts}`;
 });
@@ -70,6 +91,41 @@ const refresh = async () => {
   summary.value = await getOfflineWorkflowSummary();
   connection.value = readOfflineConnectionState();
   initialSummaryLoaded = true;
+};
+
+const setSyncMessage = (result: CheckoutQueueSyncResult) => {
+  const attentionCount = result.remaining + result.review;
+  if (result.serverReachable === false) {
+    messageKind.value = "error";
+    message.value = "ItemTraxx servers are still unreachable. Pending transactions remain safely stored.";
+  } else if (result.remaining > 0 || result.review > 0) {
+    messageKind.value = "info";
+    message.value = `Connected to ItemTraxx servers, but ${attentionCount} offline transaction${attentionCount === 1 ? "" : "s"} still need attention.`;
+  } else {
+    messageKind.value = "success";
+    message.value = "Connected to ItemTraxx servers. Offline queue is synced.";
+  }
+  if (toastTimer) window.clearTimeout(toastTimer);
+  toastTimer = window.setTimeout(() => { message.value = ""; }, result.serverReachable === false ? 12_000 : 6_000);
+};
+
+const syncNow = async (manual = false) => {
+  if (syncInFlight.value || (!manual && !navigator.onLine)) return;
+  syncInFlight.value = true;
+  try {
+    const result = await syncCheckoutQueues({ force: manual });
+    await refresh();
+    if (manual) setSyncMessage(result);
+  } catch (error) {
+    if (manual) {
+      messageKind.value = "error";
+      message.value = toUserFacingErrorMessage(error, "Unable to sync offline transactions.");
+      if (toastTimer) window.clearTimeout(toastTimer);
+      toastTimer = window.setTimeout(() => { message.value = ""; }, 12_000);
+    }
+  } finally {
+    syncInFlight.value = false;
+  }
 };
 
 const retryAfterSessionInitialization = () => {
@@ -123,6 +179,7 @@ const handleChange = () => {
   showOfflineSafetyNoticeIfNeeded();
   void refresh();
   void automaticallyRefreshPack();
+  void syncNow();
 };
 
 const handleBrowserOffline = () => {
@@ -133,9 +190,12 @@ onMounted(() => {
   void (async () => {
     await refresh();
     await automaticallyRefreshPack();
+    await refresh();
+    await syncNow();
   })();
   pollTimer = window.setInterval(() => void refresh(), 10_000);
   refreshTimer = window.setInterval(() => void automaticallyRefreshPack(), OFFLINE_PACK_REFRESH_INTERVAL_MS);
+  syncTimer = window.setInterval(() => void syncNow(), 15_000);
   window.addEventListener("online", handleChange);
   window.addEventListener("offline", handleBrowserOffline);
   window.addEventListener("itemtraxx:offline-workflow-changed", handleChange);
@@ -144,6 +204,7 @@ onMounted(() => {
 onScopeDispose(() => {
   if (pollTimer) window.clearInterval(pollTimer);
   if (refreshTimer) window.clearInterval(refreshTimer);
+  if (syncTimer) window.clearInterval(syncTimer);
   if (toastTimer) window.clearTimeout(toastTimer);
   if (sessionInitializationRetryTimer) window.clearTimeout(sessionInitializationRetryTimer);
   window.removeEventListener("online", handleChange);
@@ -156,19 +217,21 @@ onScopeDispose(() => {
 <style scoped>
 .offline-workflow-status {
   position: relative;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 0.55rem 1rem;
   padding: 0.78rem 0.9rem;
   border: 1px solid var(--border);
   border-radius: 14px;
   background: var(--surface);
 }
-.offline-workflow-status div { display: grid; gap: 0.15rem; }
+.offline-workflow-status-content { display: grid; gap: 0.15rem; min-width: 0; }
 .offline-workflow-status strong { font-size: 0.9rem; }
 .offline-workflow-status span { color: var(--muted); font-size: 0.8rem; }
+.offline-sync-button { min-height: 2.2rem; padding: 0.35rem 0.8rem; white-space: nowrap; }
 @media (max-width: 640px) {
-  .offline-workflow-status { grid-template-columns: 1fr; }
+  .offline-workflow-status { align-items: flex-start; }
+  .offline-sync-button { flex-shrink: 0; }
 }
 </style>

--- a/src/pages/workspace/Checkout.vue
+++ b/src/pages/workspace/Checkout.vue
@@ -162,7 +162,7 @@ import {
   fetchItemByBarcode,
   fetchBorrowerByBorrowerId,
   submitCheckoutReturn,
-  syncBufferedCheckoutQueue,
+  syncCheckoutQueues,
   type ItemSummary,
   type BorrowerSummary,
 } from "../../services/checkoutService";
@@ -225,12 +225,12 @@ const receipt = ref<{
   items: Array<{ name: string; barcode: string; action: "checkout" | "return" }>;
 } | null>(null);
 
-const syncOfflineBuffer = async () => {
+const syncOfflineBuffer = async (force = false) => {
   if (syncInFlight.value) return;
-  if (!navigator.onLine) return;
+  if (!force && !navigator.onLine) return;
   syncInFlight.value = true;
   try {
-    await syncBufferedCheckoutQueue();
+    await syncCheckoutQueues({ force });
     const queueWarning = consumeCheckoutOfflineWarning();
     if (queueWarning) {
       toastStatus.value = "Failed";

--- a/src/services/checkoutService.spec.ts
+++ b/src/services/checkoutService.spec.ts
@@ -43,6 +43,10 @@ vi.mock("./offlineConnectionState", () => ({
   markItemTraxxServerConfirmed: vi.fn(),
   markItemTraxxServerUnreachable: vi.fn(),
 }));
+vi.mock("./systemStatusService", () => ({
+  fetchSystemStatus: vi.fn(),
+  probeSystemStatusTransport: vi.fn(),
+}));
 
 import { invokeEdgeFunction } from "./edgeFunctionClient";
 import { authenticatedSelect } from "./authenticatedDataClient";
@@ -63,6 +67,7 @@ import {
 } from "./offlineCheckoutWorkflow";
 import { getAuthState } from "../store/authState";
 import { markItemTraxxServerConfirmed, markItemTraxxServerUnreachable } from "./offlineConnectionState";
+import { fetchSystemStatus, probeSystemStatusTransport } from "./systemStatusService";
 import {
   fetchBorrowerByBorrowerId,
   fetchCheckedOutItem,
@@ -70,6 +75,7 @@ import {
   getCheckoutOfflineSummary,
   submitCheckoutReturn,
   syncBufferedCheckoutQueue,
+  syncCheckoutQueues,
   type CheckoutReturnPayload,
 } from "./checkoutService";
 
@@ -89,6 +95,8 @@ const mockedSyncLedger = vi.mocked(syncOfflineCheckoutLedger);
 const mockedGetAuthState = vi.mocked(getAuthState);
 const mockedMarkConfirmed = vi.mocked(markItemTraxxServerConfirmed);
 const mockedMarkUnreachable = vi.mocked(markItemTraxxServerUnreachable);
+const mockedFetchSystemStatus = vi.mocked(fetchSystemStatus);
+const mockedProbeSystemStatusTransport = vi.mocked(probeSystemStatusTransport);
 
 const AUTH_SCOPE = {
   isAuthenticated: true,
@@ -124,6 +132,8 @@ beforeEach(() => {
   mockedGetAuthState.mockReturnValue(AUTH_SCOPE);
   mockedMarkConfirmed.mockReset();
   mockedMarkUnreachable.mockReset();
+  mockedFetchSystemStatus.mockReset().mockResolvedValue(null);
+  mockedProbeSystemStatusTransport.mockReset().mockResolvedValue(false);
 });
 
 afterEach(() => {
@@ -228,6 +238,17 @@ describe("submitCheckoutReturn", () => {
 
     expect(result).toEqual({ buffered: true, queuedCount: 1 });
     expect(mockedInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not silently buffer a status-zero transaction when the edge transport is reachable", async () => {
+    setOnline(true);
+    mockedInvoke.mockResolvedValue(failResponse(0, "Network request failed.") as never);
+    mockedFetchSystemStatus.mockResolvedValue(null);
+    mockedProbeSystemStatusTransport.mockResolvedValue(true);
+
+    await expect(submitCheckoutReturn(payload, { borrower: null, items: [] })).rejects.toThrow(/network request failed/i);
+    expect(mockedQueueOfflineOperation).not.toHaveBeenCalled();
+    expect(mockedMarkUnreachable).not.toHaveBeenCalled();
   });
 
   it("throws when a queueable failure occurs but there is no offline context to buffer into", async () => {
@@ -335,6 +356,66 @@ describe("syncBufferedCheckoutQueue", () => {
   });
 });
 
+describe("syncCheckoutQueues", () => {
+  it("does not start a sync while the browser is explicitly offline", async () => {
+    setOnline(false);
+
+    await expect(syncCheckoutQueues()).resolves.toEqual({
+      processed: 0,
+      failed: 0,
+      remaining: 0,
+      review: 0,
+      serverReachable: null,
+    });
+    expect(mockedSyncLedger).not.toHaveBeenCalled();
+    expect(mockedFetchSystemStatus).not.toHaveBeenCalled();
+  });
+
+  it("treats an HTTP application error as reachable instead of marking the browser offline", async () => {
+    setOnline(true);
+    mockedSyncLedger.mockResolvedValue({ processed: 0, failed: 0, remaining: 0, review: 0 });
+    mockedFetchSystemStatus.mockResolvedValue({ ok: false, status: 503, payload: {} });
+
+    await expect(syncCheckoutQueues({ force: true })).resolves.toMatchObject({ serverReachable: true });
+    expect(mockedMarkConfirmed).toHaveBeenCalled();
+    expect(mockedMarkUnreachable).not.toHaveBeenCalled();
+  });
+
+  it("forces a fresh borrower and item pack after a reconnect drains the offline queue", async () => {
+    setOnline(true);
+    mockedSyncLedger.mockResolvedValue({ processed: 1, failed: 0, remaining: 0, review: 0 });
+    mockedFetchSystemStatus.mockResolvedValue({ ok: true, status: 200, payload: {} });
+
+    await expect(syncCheckoutQueues({ force: true })).resolves.toMatchObject({
+      processed: 1,
+      remaining: 0,
+      review: 0,
+      serverReachable: true,
+    });
+    expect(mockedRefreshPack).toHaveBeenCalledWith({ force: true });
+  });
+
+  it("does not replace the local pack while replay still has pending or review work", async () => {
+    setOnline(true);
+    mockedSyncLedger.mockResolvedValue({ processed: 1, failed: 1, remaining: 1, review: 0 });
+    mockedFetchSystemStatus.mockResolvedValue({ ok: true, status: 200, payload: {} });
+
+    await syncCheckoutQueues({ force: true });
+
+    expect(mockedRefreshPack).not.toHaveBeenCalled();
+  });
+
+  it("keeps a failed transport probe offline only when both application and no-cors probes fail", async () => {
+    setOnline(true);
+    mockedSyncLedger.mockResolvedValue({ processed: 0, failed: 0, remaining: 0, review: 0 });
+    mockedFetchSystemStatus.mockResolvedValue(null);
+    mockedProbeSystemStatusTransport.mockResolvedValue(false);
+
+    await expect(syncCheckoutQueues({ force: true })).resolves.toMatchObject({ serverReachable: false });
+    expect(mockedMarkUnreachable).toHaveBeenCalled();
+  });
+});
+
 describe("fetchItemByBarcode", () => {
   it("looks up the item offline immediately when the browser reports offline", async () => {
     setOnline(false);
@@ -421,13 +502,31 @@ describe("fetchBorrowerByBorrowerId", () => {
     expect(mockedMarkConfirmed).toHaveBeenCalled();
   });
 
-  it("falls back to the offline pack on a server failure without labeling the reachable server offline", async () => {
+  it("surfaces a server failure without labeling the reachable server offline", async () => {
     setOnline(true);
     mockedInvoke.mockResolvedValue(failResponse(503) as never);
-    mockedFindOfflineBorrower.mockResolvedValue({ id: "b-1", username: "jdoe", borrower_id: "1234AB" });
 
-    const result = await fetchBorrowerByBorrowerId("1234AB");
-    expect(result).toMatchObject({ id: "b-1" });
+    await expect(fetchBorrowerByBorrowerId("1234AB")).rejects.toThrow("boom");
+    expect(mockedMarkUnreachable).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a borrower authorization 403 without showing the offline workflow", async () => {
+    setOnline(true);
+    mockedInvoke.mockResolvedValue(failResponse(403, "Forbidden.") as never);
+
+    await expect(fetchBorrowerByBorrowerId("1234AB")).rejects.toThrow("Forbidden.");
+    expect(mockedFindOfflineBorrower).not.toHaveBeenCalled();
+    expect(mockedMarkUnreachable).not.toHaveBeenCalled();
+  });
+
+  it("does not turn a CORS/WAF-looking status-zero lookup into an offline warning when the edge is reachable", async () => {
+    setOnline(true);
+    mockedInvoke.mockResolvedValue(failResponse(0, "Network request failed.") as never);
+    mockedFetchSystemStatus.mockResolvedValue(null);
+    mockedProbeSystemStatusTransport.mockResolvedValue(true);
+
+    await expect(fetchBorrowerByBorrowerId("1234AB")).rejects.toThrow(/network request failed/i);
+    expect(mockedFindOfflineBorrower).not.toHaveBeenCalled();
     expect(mockedMarkUnreachable).not.toHaveBeenCalled();
   });
 

--- a/src/services/checkoutService.ts
+++ b/src/services/checkoutService.ts
@@ -25,10 +25,10 @@ import {
 } from "./offlineCheckoutWorkflow";
 import { getAuthState } from "../store/authState";
 import {
-  isServerUnreachableStatus,
   markItemTraxxServerConfirmed,
   markItemTraxxServerUnreachable,
 } from "./offlineConnectionState";
+import { fetchSystemStatus, probeSystemStatusTransport } from "./systemStatusService";
 
 export { consumeCheckoutOfflineWarning } from "./offlineCheckoutQueue";
 export type { CheckoutReturnPayload } from "./offlineCheckoutQueue";
@@ -37,6 +37,16 @@ type SubmitCheckoutReturnResult = {
   buffered: boolean;
   queuedCount: number;
 };
+
+export type CheckoutQueueSyncResult = {
+  processed: number;
+  failed: number;
+  remaining: number;
+  review: number;
+  serverReachable: boolean | null;
+};
+
+type BufferedCheckoutQueueSyncResult = Omit<CheckoutQueueSyncResult, "serverReachable">;
 
 export type OfflineSubmitContext = {
   borrower: OfflinePackBorrower | null;
@@ -52,6 +62,7 @@ type CheckoutReturnResponse = {
 };
 
 const LOOKUP_TIMEOUT_MS = 7000;
+const SERVER_PROBE_TIMEOUT_MS = 2000;
 
 const isRetryableNetworkFailure = (status: number, message: string) => {
   if (status === 0) return true;
@@ -77,9 +88,8 @@ const isQueueableFailure = (error: unknown) => {
   return isRetryableNetworkFailure(0, message);
 };
 
-const recordCheckoutResponse = (ok: boolean, status: number) => {
+const recordCheckoutResponse = (ok: boolean) => {
   if (ok) markItemTraxxServerConfirmed();
-  else if (isServerUnreachableStatus(status)) markItemTraxxServerUnreachable();
 };
 
 const isLookupConnectivityFailure = (error: unknown) => {
@@ -105,7 +115,7 @@ const executeCheckoutReturn = async (payload: CheckoutReturnPayload) => {
     },
   });
 
-  recordCheckoutResponse(result.ok, result.status);
+  recordCheckoutResponse(result.ok);
 
   if (!result.ok) {
     const message = result.status === 429
@@ -156,6 +166,12 @@ export const submitCheckoutReturn = async (
           };
         } catch (retryError) {
           if (!isQueueableFailure(retryError)) throw retryError;
+          if (retryError instanceof CheckoutRequestError && retryError.status === 0 && await probeItemTraxxServer()) {
+            // A CORS/WAF failure can look like a network outage to fetch even
+            // while the edge is reachable. Do not silently turn that request
+            // into an offline transaction; let the operator retry it.
+            throw retryError;
+          }
         }
       }
       if (!offlineContext || !payloadWithOperationId.operation_id) {
@@ -172,7 +188,7 @@ export const submitCheckoutReturn = async (
   }
 };
 
-export const syncBufferedCheckoutQueue = async () => {
+const syncBufferedCheckoutQueueInternal = async () => {
   const auth = getAuthState();
   if (!auth.isAuthenticated || !auth.workspaceContextId || !auth.userId) {
     // Checkout can mount while auth is still settling (for example after a
@@ -229,6 +245,80 @@ export const syncBufferedCheckoutQueue = async () => {
   };
 };
 
+let bufferedCheckoutQueueSyncInFlight: Promise<BufferedCheckoutQueueSyncResult> | null = null;
+let checkoutQueueSyncInFlight: Promise<CheckoutQueueSyncResult> | null = null;
+
+const refreshOfflinePackAfterQueueSync = async (
+  result: BufferedCheckoutQueueSyncResult,
+  serverReachable: boolean | null = true,
+) => {
+  if (result.processed === 0 || result.remaining > 0 || result.review > 0 || serverReachable === false) return;
+  await refreshOfflineCheckoutPackIfNeeded({ force: true }).catch(() => undefined);
+};
+
+export const probeItemTraxxServer = async () => {
+  try {
+    const result = await fetchSystemStatus({ force: true, timeoutMs: SERVER_PROBE_TIMEOUT_MS });
+    if (result) {
+      // Any HTTP response proves the edge is reachable. Application-level
+      // failures must not turn into a misleading offline label.
+      markItemTraxxServerConfirmed();
+      return true;
+    }
+  } catch {
+    // A failed status probe is the only place a fetch-level failure is
+    // promoted to the persistent offline state.
+  }
+  if (await probeSystemStatusTransport(SERVER_PROBE_TIMEOUT_MS)) {
+    // A CORS/WAF challenge can make the application probe look like a network
+    // failure even though the edge is reachable. Keep that distinct from an
+    // actual outage so a borrower lookup cannot flash an offline warning.
+    markItemTraxxServerConfirmed();
+    return true;
+  }
+  markItemTraxxServerUnreachable();
+  return false;
+};
+
+export const syncBufferedCheckoutQueue = () => {
+  if (!bufferedCheckoutQueueSyncInFlight) {
+    bufferedCheckoutQueueSyncInFlight = (async () => {
+      const result = await syncBufferedCheckoutQueueInternal();
+      await refreshOfflinePackAfterQueueSync(result);
+      return result;
+    })().finally(() => { bufferedCheckoutQueueSyncInFlight = null; });
+  }
+  return bufferedCheckoutQueueSyncInFlight;
+};
+
+/**
+ * Replays both offline queue formats and actively verifies that ItemTraxx is
+ * reachable. `force` is used by the manual Sync now control so a stale
+ * navigator.onLine value cannot prevent the request.
+ */
+export const syncCheckoutQueues = (options: { force?: boolean } = {}) => {
+  if (!options.force && typeof navigator !== "undefined" && !navigator.onLine) {
+    return Promise.resolve<CheckoutQueueSyncResult>({
+      processed: 0,
+      failed: 0,
+      remaining: 0,
+      review: 0,
+      serverReachable: null,
+    });
+  }
+  if (!checkoutQueueSyncInFlight) {
+    checkoutQueueSyncInFlight = (async () => {
+      const result = await syncBufferedCheckoutQueueInternal();
+      const serverReachable = await probeItemTraxxServer();
+      await refreshOfflinePackAfterQueueSync(result, serverReachable);
+      return { ...result, serverReachable };
+    })().finally(() => {
+      checkoutQueueSyncInFlight = null;
+    });
+  }
+  return checkoutQueueSyncInFlight;
+};
+
 export type BorrowerSummary = {
   id: string;
   username: string;
@@ -265,7 +355,7 @@ export const fetchItemByBarcode = async (barcode: string) => {
     markItemTraxxServerConfirmed();
   } catch (error) {
     if (!isLookupConnectivityFailure(error)) throw error;
-    markItemTraxxServerUnreachable();
+    if (await probeItemTraxxServer()) throw error;
     const offline = await findOfflineItem(getOfflineScope(), barcode);
     if (offline) return offline as ItemSummary;
     throw error;
@@ -301,14 +391,15 @@ export const fetchBorrowerByBorrowerId = async (borrowerId: string) => {
     );
   } catch (error) {
     if (!isLookupConnectivityFailure(error)) throw error;
-    markItemTraxxServerUnreachable();
+    if (await probeItemTraxxServer()) throw error;
     const offline = await findOfflineBorrower(getOfflineScope(), borrowerId);
     if (offline) return offline as BorrowerSummary;
     throw error;
   }
 
-  if (result.status === 0 || result.status === 429 || result.status >= 500) {
-    if (isServerUnreachableStatus(result.status)) markItemTraxxServerUnreachable();
+  if (result.status === 0) {
+    const serverReachable = await probeItemTraxxServer();
+    if (serverReachable) throw edgeFunctionError(result, "Borrower lookup failed. Please try again.");
     const offline = await findOfflineBorrower(getOfflineScope(), borrowerId);
     if (offline) return offline as BorrowerSummary;
   } else if (result.ok) {
@@ -341,7 +432,7 @@ export const fetchCheckedOutItem = async (borrowerUuid: string) => {
     markItemTraxxServerConfirmed();
   } catch (error) {
     if (!isLookupConnectivityFailure(error)) throw error;
-    markItemTraxxServerUnreachable();
+    if (await probeItemTraxxServer()) throw error;
     const offline = await getOfflineCheckedOutItems(getOfflineScope(), borrowerUuid);
     if (offline) return offline as ItemSummary[];
     throw error;

--- a/src/services/offlineCheckoutWorkflow.spec.ts
+++ b/src/services/offlineCheckoutWorkflow.spec.ts
@@ -238,6 +238,30 @@ describe("queueOfflineOperation", () => {
       expected_status: "available",
     });
   });
+
+  it("materializes every queued offline action into the cached item snapshot", async () => {
+    const pack = makePack();
+    await writeOfflinePack(pack);
+
+    await queueOfflineOperation({
+      operationId: "op-checkout",
+      borrower: { id: "b-2", username: "new-borrower", borrower_id: "9999ZZ" },
+      items: [{ item: pack.items[0]!, intent: "checkout" }],
+    });
+    let cached = await readOfflinePack({ workspaceId: WORKSPACE_ID, profileId: PROFILE_ID, deviceId: DEVICE_ID });
+    expect(cached!.borrowers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "b-2", borrower_id: "9999ZZ" }),
+    ]));
+    expect(cached!.items[0]).toMatchObject({ status: "checked_out", checked_out_by: "b-2" });
+
+    await queueOfflineOperation({
+      operationId: "op-return",
+      borrower: { id: "b-2", username: "new-borrower", borrower_id: "9999ZZ" },
+      items: [{ item: cached!.items[0]!, intent: "return" }],
+    });
+    cached = await readOfflinePack({ workspaceId: WORKSPACE_ID, profileId: PROFILE_ID, deviceId: DEVICE_ID });
+    expect(cached!.items[0]).toMatchObject({ status: "available", checked_out_by: null });
+  });
 });
 
 describe("getOfflineWorkflowSummary", () => {
@@ -572,6 +596,25 @@ describe("refreshOfflineCheckoutPackIfNeeded", () => {
 
     resolveInvoke({ ok: true, status: 200, error: "", data: { data: prepared } });
     await first;
+    expect(mockedInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs a forced refresh after an in-flight timer check reports the pack is current", async () => {
+    setAuthStateFromBackend({ isAuthenticated: true, userId: PROFILE_ID, workspaceContextId: WORKSPACE_ID });
+    const existing = makePack({ prepared_at: new Date().toISOString() });
+    await writeOfflinePack(existing);
+    mockedInvoke.mockResolvedValue({
+      ok: true,
+      status: 200,
+      error: "",
+      data: { data: { ...existing, pack_version: "v2" } },
+    });
+
+    const timerRefresh = refreshOfflineCheckoutPackIfNeeded();
+    const forcedRefresh = refreshOfflineCheckoutPackIfNeeded({ force: true });
+
+    await expect(timerRefresh).resolves.toEqual({ refreshed: false, firstPreparation: false, skippedReason: "up_to_date" });
+    await expect(forcedRefresh).resolves.toEqual({ refreshed: true, firstPreparation: false });
     expect(mockedInvoke).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/services/offlineCheckoutWorkflow.ts
+++ b/src/services/offlineCheckoutWorkflow.ts
@@ -2,9 +2,7 @@ import { invokeEdgeFunction } from "./edgeFunctionClient";
 import { getOrCreateDeviceSession } from "../utils/deviceSession";
 import { getAuthState } from "../store/authState";
 import {
-  isServerUnreachableStatus,
   markItemTraxxServerConfirmed,
-  markItemTraxxServerUnreachable,
 } from "./offlineConnectionState";
 
 export type OfflinePackBorrower = {
@@ -86,6 +84,11 @@ type SyncOperationResult = {
   resolution?: "keep_server" | "apply_offline";
   item_results: SyncItemResult[];
 };
+type OfflinePackRefreshResult = {
+  refreshed: boolean;
+  firstPreparation: boolean;
+  skippedReason?: "offline" | "unauthenticated" | "pending_transactions" | "up_to_date";
+};
 
 const DATABASE_NAME = "itemtraxx-offline-workflow";
 const DATABASE_VERSION = 1;
@@ -108,17 +111,13 @@ const ACTIVE_LEDGER_STATES = new Set<OfflineLedgerEntry["status"]>([
   "syncing",
   "needs_review",
 ]);
-let automaticPackRefresh: Promise<{
-  refreshed: boolean;
-  firstPreparation: boolean;
-  skippedReason?: "offline" | "unauthenticated" | "pending_transactions" | "up_to_date";
-}> | null = null;
+let automaticPackRefresh: Promise<OfflinePackRefreshResult> | null = null;
+let automaticPackRefreshWasForced = false;
 
 const isRetryableWorkflowStatus = (status: number) => status === 0 || status === 429 || status >= 500;
 
-const recordWorkflowResponse = (ok: boolean, status: number) => {
+const recordWorkflowResponse = (ok: boolean) => {
   if (ok) markItemTraxxServerConfirmed();
-  else if (isServerUnreachableStatus(status)) markItemTraxxServerUnreachable();
 };
 
 const createId = () =>
@@ -337,7 +336,7 @@ export const prepareOfflineCheckoutPack = async () => {
     "offline-checkout",
     { method: "POST", body: { action: "prepare_pack", device_id: deviceId } },
   );
-  recordWorkflowResponse(response.ok, response.status);
+  recordWorkflowResponse(response.ok);
   if (!response.ok || !response.data?.data) throw new Error(response.error || "Unable to prepare offline checkout.");
   const pack: OfflineCheckoutPack = {
     ...response.data.data,
@@ -357,8 +356,16 @@ export const prepareOfflineCheckoutPack = async () => {
  */
 export const refreshOfflineCheckoutPackIfNeeded = (
   options: { force?: boolean } = {},
-) => {
-  if (automaticPackRefresh) return automaticPackRefresh;
+): Promise<OfflinePackRefreshResult> => {
+  if (automaticPackRefresh) {
+    if (!options.force || automaticPackRefreshWasForced) return automaticPackRefresh;
+    // A forced refresh requested while a non-forced timer refresh is in
+    // flight must run again after that stale check completes. Returning the
+    // in-flight promise would otherwise turn the forced refresh into a no-op.
+    return automaticPackRefresh.catch(() => undefined).then(() => refreshOfflineCheckoutPackIfNeeded(options));
+  }
+
+  automaticPackRefreshWasForced = !!options.force;
 
   automaticPackRefresh = (async () => {
     if (typeof navigator !== "undefined" && !navigator.onLine) {
@@ -389,6 +396,7 @@ export const refreshOfflineCheckoutPackIfNeeded = (
     return { refreshed: true, firstPreparation: !existingPack };
   })().finally(() => {
     automaticPackRefresh = null;
+    automaticPackRefreshWasForced = false;
   });
 
   return automaticPackRefresh;
@@ -421,6 +429,34 @@ const applyLedgerOverlay = (pack: OfflineCheckoutPack, entries: OfflineLedgerEnt
     }
   }
   return [...items.values()];
+};
+
+/**
+ * Materializes the current ledger overlay and the action's borrower into the
+ * encrypted pack immediately after an offline action. The ledger remains the
+ * source of truth for replay, while the pack itself stays useful to any code
+ * that reads the snapshot without applying the overlay first.
+ */
+export const refreshOfflineCheckoutCacheFromLedger = async (borrower: OfflinePackBorrower | null = null) => {
+  const auth = getAuthState();
+  if (!auth.workspaceContextId || !auth.userId) return false;
+  const { deviceId } = getOrCreateDeviceSession();
+  const scope = { workspaceId: auth.workspaceContextId, profileId: auth.userId, deviceId };
+
+  return withOfflineWorkflowLock(async () => {
+    const pack = await readRecord<OfflineCheckoutPack | null>(PACK_ID, null);
+    if (!pack || !scopeMatches(pack, scope) || Date.parse(pack.expires_at) <= Date.now()) return false;
+    const nextItems = applyLedgerOverlay(pack, await readOfflineLedger());
+    const nextBorrowers = borrower
+      ? [
+          ...pack.borrowers.filter((item) => item.id !== borrower.id && item.borrower_id !== borrower.borrower_id),
+          borrower,
+        ]
+      : pack.borrowers;
+    await writeRecord(PACK_ID, { ...pack, borrowers: nextBorrowers, items: nextItems });
+    window.dispatchEvent(new CustomEvent("itemtraxx:offline-workflow-changed"));
+    return true;
+  });
 };
 
 const getOverlay = async (scope: OfflineWorkflowScope) => {
@@ -509,6 +545,12 @@ export const queueOfflineOperation = async (draft: {
     })),
   };
   const next = await updateLedger((entries) => [...entries, entry]);
+  try {
+    await refreshOfflineCheckoutCacheFromLedger(draft.borrower);
+  } catch {
+    // The encrypted ledger is already durable; a snapshot write failure must
+    // not turn a successfully queued offline action into a failed transaction.
+  }
   return next.filter((item) => ACTIVE_LEDGER_STATES.has(item.status)).length;
 };
 
@@ -622,7 +664,7 @@ export const syncOfflineCheckoutLedger = async () => {
       })),
     },
   });
-  recordWorkflowResponse(response.ok, response.status);
+  recordWorkflowResponse(response.ok);
   if (!response.ok || !response.data?.data) {
     const retryable = isRetryableWorkflowStatus(response.status);
     const reason = response.error || "Unable to sync offline transactions.";
@@ -680,7 +722,7 @@ export const resolveOfflineCheckoutConflict = async (
     },
     preserveErrorData: true,
   });
-  recordWorkflowResponse(response.ok, response.status);
+  recordWorkflowResponse(response.ok);
   if (response.data?.data) {
     await updateLedger((entries) => entries.map((item) => item.id === entryId
       ? applyOperationResult({ ...item, resolution }, response.data!.data)

--- a/src/services/systemStatusService.spec.ts
+++ b/src/services/systemStatusService.spec.ts
@@ -5,7 +5,7 @@ vi.mock("./edgeUrls", () => ({
 }));
 
 import { getEdgeFunctionsBaseUrl } from "./edgeUrls";
-import { fetchSystemStatus } from "./systemStatusService";
+import { fetchSystemStatus, probeSystemStatusTransport } from "./systemStatusService";
 
 const mockedBaseUrl = vi.mocked(getEdgeFunctionsBaseUrl);
 
@@ -119,5 +119,33 @@ describe("fetchSystemStatus", () => {
     await Promise.all([first, second]);
 
     expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("probeSystemStatusTransport", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    mockedBaseUrl.mockReturnValue("/functions");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("recognizes an opaque/no-cors response as reachable", async () => {
+    vi.mocked(fetch).mockResolvedValue({ type: "opaque" } as Response);
+
+    await expect(probeSystemStatusTransport()).resolves.toBe(true);
+    expect(fetch).toHaveBeenCalledWith(
+      "/functions/system-status",
+      expect.objectContaining({ method: "GET", mode: "no-cors", cache: "no-store" }),
+    );
+  });
+
+  it("returns false when the transport request fails", async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error("network down"));
+
+    await expect(probeSystemStatusTransport()).resolves.toBe(false);
   });
 });

--- a/src/services/systemStatusService.ts
+++ b/src/services/systemStatusService.ts
@@ -77,6 +77,33 @@ const triggerRevalidate = (timeoutMs: number) => {
   return pendingRequest;
 };
 
+/**
+ * Check whether the edge host can be reached without requiring a CORS
+ * response. A managed edge challenge can reject a normal browser fetch before
+ * application code sees the HTTP status; a no-cors request still distinguishes
+ * that reachable edge from an actual network outage.
+ */
+export const probeSystemStatusTransport = async (timeoutMs = 3500) => {
+  const functionsBaseUrl = getEdgeFunctionsBaseUrl();
+  if (!functionsBaseUrl) return false;
+
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    await fetch(`${functionsBaseUrl}/${STATUS_FUNCTION_NAME}`, {
+      method: "GET",
+      mode: "no-cors",
+      cache: "no-store",
+      signal: controller.signal,
+    });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+};
+
 export const fetchSystemStatus = async (options: {
   force?: boolean;
   timeoutMs?: number;

--- a/tests/e2e/checkout-offline.spec.ts
+++ b/tests/e2e/checkout-offline.spec.ts
@@ -993,6 +993,14 @@ test.describe("prepared offline checkout workflow contract", () => {
     });
     await page.route(/\/functions(?:\/v1)?\/offline-checkout(?:\?.*)?$/, async (route) => {
       const body = route.request().postDataJSON() as { action?: string };
+      if (body.action === "prepare_pack") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ data: { ...workflowPack(), prepared_at: new Date().toISOString() } }),
+        });
+        return;
+      }
       expect(body.action).toBe("sync");
       await new Promise((resolve) => setTimeout(resolve, 500));
       await route.fulfill({
@@ -1015,6 +1023,116 @@ test.describe("prepared offline checkout workflow contract", () => {
     await expect(page.getByText("Syncing 1 transaction to ItemTraxx Servers.")).toBeVisible();
     await expect(page.getByText("Offline queue synced")).toBeVisible();
     await expect(page.getByText("1 transaction synced to ItemTraxx Servers.")).toBeVisible();
+  });
+
+  test("lets an operator manually retry a pending sync from the checkout status bar", async ({ page }) => {
+    await mockSystemStatus(page);
+    await setWorkspaceAdminSession(page, "workspace-e2e");
+    await page.evaluate(async ({ pack, entry }) => {
+      window.localStorage.setItem("itemtraxx-device-id", "device-e2e");
+      window.localStorage.setItem("itemtraxx:onboarding:v1:workspace_admin", new Date().toISOString());
+      window.localStorage.setItem("itemtraxx:offline-connection:v1", JSON.stringify({
+        last_confirmed_at: new Date(Date.now() - 60_000).toISOString(),
+        unreachable_since: new Date(Date.now() - 30_000).toISOString(),
+        acknowledged_hours: 0,
+      }));
+      const workflow = (window.__itemtraxxTest as typeof window.__itemtraxxTest & {
+        offlineCheckoutWorkflow: {
+          writePack: (pack: unknown) => Promise<void>;
+          writeLedger: (entries: unknown[]) => Promise<void>;
+          readPack: (scope: { workspaceId: string; profileId: string; deviceId: string }) => Promise<unknown>;
+        };
+      }).offlineCheckoutWorkflow;
+      await workflow.writePack(pack);
+      await workflow.writeLedger([entry]);
+    }, {
+      pack: {
+        ...workflowPack(),
+        prepared_at: new Date().toISOString(),
+        expires_at: new Date(Date.now() + 86_400_000).toISOString(),
+      },
+      entry: workflowEntry(),
+    });
+
+    let syncAttempts = 0;
+    let preparePackAttempts = 0;
+    await page.route(/\/functions(?:\/v1)?\/offline-checkout(?:\?.*)?$/, async (route) => {
+      const body = route.request().postDataJSON() as { action?: string };
+      if (body.action === "prepare_pack") {
+        preparePackAttempts += 1;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            data: {
+              pack_version: "refreshed-pack-workflow-e2e",
+              workspace_id: "workspace-e2e",
+              prepared_at: new Date().toISOString(),
+              expires_at: new Date(Date.now() + 86_400_000).toISOString(),
+              borrowers: [
+                { id: "borrower-1", username: "Maya Chen (updated)", borrower_id: "STU-100" },
+                { id: "borrower-2", username: "Jon Bell", borrower_id: "STU-200" },
+              ],
+              items: [
+                { id: "item-1", name: "Camera", barcode: "ITEM-1", status: "checked_out", checked_out_by: "borrower-1" },
+                { id: "item-2", name: "Tripod", barcode: "ITEM-2", status: "available", checked_out_by: null },
+              ],
+            },
+          }),
+        });
+        return;
+      }
+      expect(body.action).toBe("sync");
+      syncAttempts += 1;
+      if (syncAttempts === 1) {
+        await route.fulfill({
+          status: 503,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Temporary sync outage." }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: {
+            operations: [{
+              operation_id: "op-workflow-e2e",
+              status: "synced",
+              item_results: [{ item_id: "item-1", barcode: "ITEM-1", status: "synced" }],
+            }],
+          },
+        }),
+      });
+    });
+    await navigateApp(page, "/checkout");
+
+    const syncButton = page.getByRole("button", { name: "Sync now" });
+    await expect(syncButton).toBeVisible();
+    await expect(syncButton).toBeEnabled();
+    await syncButton.click();
+
+    await expect(page.getByText("Connected to ItemTraxx servers. Offline queue is synced.")).toBeVisible();
+    await expect.poll(() => syncAttempts).toBeGreaterThanOrEqual(2);
+    await expect.poll(() => preparePackAttempts).toBe(1);
+    await expect.poll(async () => page.evaluate(async () => {
+      const workflow = (window.__itemtraxxTest as typeof window.__itemtraxxTest & {
+        offlineCheckoutWorkflow: {
+          readPack: (scope: { workspaceId: string; profileId: string; deviceId: string }) => Promise<unknown>;
+        };
+      }).offlineCheckoutWorkflow;
+      return workflow.readPack({ workspaceId: "workspace-e2e", profileId: "user-e2e-admin", deviceId: "device-e2e" });
+    })).toMatchObject({
+      pack_version: "refreshed-pack-workflow-e2e",
+      borrowers: expect.arrayContaining([expect.objectContaining({ borrower_id: "STU-200" })]),
+      items: expect.arrayContaining([expect.objectContaining({ barcode: "ITEM-1", status: "checked_out", checked_out_by: "borrower-1" })]),
+    });
+    await expect(page.getByRole("button", { name: "Sync now" })).toHaveCount(0);
+    await expect.poll(async () => page.evaluate(() => {
+      const raw = window.localStorage.getItem("itemtraxx:offline-connection:v1");
+      return (JSON.parse(raw ?? "null") as { unreachable_since?: string | null } | null)?.unreachable_since ?? null;
+    })).toBeNull();
   });
 
   test("queues Quick Return with an explicit quick_return intent and current borrower", async ({ page, context }) => {


### PR DESCRIPTION
Promote the validated staging merge to preview.

Source:
- staging merge commit: `961ab3187f2dd32614cfa335205609a71a5886c3`
- includes frontend offline checkout cache synchronization and manual/automatic queue refresh behavior from PR #945 (`1b906e601a42e5a4998f53cb8f32a980f6051cda`)

Validation:
- staging push CI run 32606540476 passed (frontend unit/e2e, build, edge contract checks, security gate, CodeQL)
- exact staging SHA has no active or failing checks
- no `supabase/functions/**`, `supabase/config.toml`, or `cloudflare/edge-proxy/**` paths changed; provider deploy workflows are not expected for this promotion
