### PR TITLE
fix(analytics): capture pageleave events

### DIFF
--- a/src/services/posthogService.spec.ts
+++ b/src/services/posthogService.spec.ts
@@ -77,6 +77,7 @@ describe("initPostHog", () => {
       expect.objectContaining({
         capture_exceptions: true,
         autocapture: false,
+        capture_pageleave: true,
         disable_session_recording: true,
       })
     );

--- a/src/services/posthogService.ts
+++ b/src/services/posthogService.ts
@@ -95,7 +95,7 @@ export const initPostHog = async () => {
       autocapture: false,
       rageclick: false,
       capture_pageview: "history_change",
-      capture_pageleave: false,
+      capture_pageleave: true,
       capture_dead_clicks: false,
       capture_exceptions: true,
       before_send: (event) => {


### PR DESCRIPTION
resolves posthog inbox issue

## Summary

- Enable PostHog `$pageleave` capture alongside the existing history-change `$pageview` capture so active web traffic records page exits.
- Add a regression assertion for the `capture_pageleave: true` initialization setting.

## Implementation

- `src/services/posthogService.ts`: change `capture_pageleave` from `false` to `true`.
- `src/services/posthogService.spec.ts`: assert that PostHog is initialized with pageleave capture enabled.

## Validation

- `npm exec vitest run src/services/posthogService.spec.ts` (19 passed)
- `npm run test:unit -- --reporter=dot` (81 files, 879 tests passed)
- `npm run build`
- `git diff --check`

## Tracking

- PostHog Inbox: [Add $pageleave capture for active web traffic](https://us.posthog.com/project/382681/inbox/019f8216-7872-799d-a111-fa3f11cd2b97)
