### PR TITLE
fix(deps): upgrade fast-uri to 3.1.6

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1533,8 +1533,8 @@
         "pako"
       ]
     },
-    "fast-uri@3.1.5": {
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="
+    "fast-uri@3.1.6": {
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q=="
     },
     "fdir@6.5.0_picomatch@4.0.5": {
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
@@ -2821,7 +2821,7 @@
         "protobufjs@<=8.2.0": "8.2.0",
         "ws": "^8.20.1",
         "dompurify": "3.4.14",
-        "fast-uri": "3.1.5",
+        "fast-uri": "3.1.6",
         "sharp": "0.35.3",
         "undici": "7.29.0",
         "js-yaml": "4.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3741,9 +3741,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "protobufjs@<=8.2.0": "8.2.0",
     "ws": "^8.20.1",
     "dompurify": "3.4.14",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "sharp": "0.35.3",
     "undici": "7.29.0",
     "js-yaml": "4.3.1",


### PR DESCRIPTION
## Summary

- Upgrade the fast-uri override from 3.1.5 to 3.1.6.
- Synchronize package-lock.json and deno.lock integrity/package records.
- Resolve the four fast-uri CVEs shown in the Aikido finding.

## Validation

- npm ci --ignore-scripts
- npm run test:prerender
- npm run build
- npm run test:unit -- --no-file-parallelism --maxWorkers=1
- npm run security:gate
- npm run worker:typecheck
- deno install --lockfile-only --frozen --min-dep-age=0
- deno check --frozen targeted Supabase functions
- targeted fast-uri normalization/SSRF regression probes

The SAST finding in scripts/prerender-public.mjs was reviewed as a trusted build-time file read and is unchanged. Local checks used Node 26.7.0; CI is pinned to Node 24.15.0.