### PR TITLE
Fix session handling and auth

### DIFF
--- a/src/services/auth/workspaceLogin.spec.ts
+++ b/src/services/auth/workspaceLogin.spec.ts
@@ -18,10 +18,6 @@ vi.mock("../httpSessionService", () => ({
   fetchHttpSessionSummary: vi.fn(),
 }));
 
-vi.mock("../adminOpsService", () => ({
-  touchAccountSession: vi.fn(),
-}));
-
 vi.mock("../auditLogService", () => ({
   logAdminAction: vi.fn(),
 }));
@@ -36,7 +32,6 @@ import { invokeEdgeFunction } from "../edgeFunctionClient";
 import { getWorkspaceState } from "../../store/workspaceState";
 import { getAuthState, setWorkspaceContext } from "../../store/authState";
 import { exchangeHttpSession, fetchHttpSessionSummary } from "../httpSessionService";
-import { touchAccountSession } from "../adminOpsService";
 import { logAdminAction } from "../auditLogService";
 import { applyHttpSessionSummary, resolveWorkspaceSlug } from "./sessionBootstrap";
 
@@ -96,7 +91,6 @@ describe("workspaceLogin", () => {
     vi.mocked(exchangeHttpSession).mockResolvedValue({ authenticated: true, user: { id: "u1", email: "a@b.com", last_sign_in_at: null }, profile: null });
     vi.mocked(applyHttpSessionSummary).mockResolvedValue(undefined);
     vi.mocked(resolveWorkspaceSlug).mockResolvedValue("resolved-slug");
-    vi.mocked(touchAccountSession).mockResolvedValue({ ok: true });
     vi.mocked(logAdminAction).mockResolvedValue(undefined);
   });
 
@@ -122,7 +116,6 @@ describe("workspaceLogin", () => {
     expect(exchangeHttpSession).toHaveBeenCalledWith({ access_token: "at-1", refresh_token: "rt-1" });
     expect(applyHttpSessionSummary).toHaveBeenCalled();
     expect(setWorkspaceContext).toHaveBeenCalledWith("ws-1");
-    expect(touchAccountSession).not.toHaveBeenCalled();
     expect(logAdminAction).not.toHaveBeenCalled();
     // workspace_slug came back from the login response, so resolveWorkspaceSlug is skipped.
     expect(resolveWorkspaceSlug).not.toHaveBeenCalled();
@@ -146,26 +139,18 @@ describe("workspaceLogin", () => {
       error: "",
       data: { access_token: "at-1", refresh_token: "rt-1" },
     });
-    const trackingOrder: string[] = [];
-    vi.mocked(touchAccountSession).mockImplementation(async () => {
-      trackingOrder.push("touch");
-      return { ok: true };
-    });
-    vi.mocked(logAdminAction).mockImplementation(async () => {
-      trackingOrder.push("audit");
-    });
 
     const result = await workspaceLogin("admin@example.com", "hunter2");
 
-    expect(touchAccountSession).toHaveBeenCalledWith({
-      loginMethod: "password",
-      loginLocation: "admin_login",
-    });
+    // Session registration happens on the destination page's login_ctx
+    // handling (see useAdminSessionLifecycle), not here: workspace_admin
+    // logins that aren't already on the workspace subdomain get a full-page
+    // redirect to a different origin, so touching the session on this
+    // (pre-redirect) origin would create an orphan device row.
     expect(logAdminAction).toHaveBeenCalledWith({
       action_type: "admin_login",
       metadata: { email: "admin@example.com" },
     });
-    expect(trackingOrder).toEqual(["touch", "audit"]);
     expect(resolveWorkspaceSlug).toHaveBeenCalledWith("ws-2");
     expect(invokeEdgeFunction).toHaveBeenNthCalledWith(2, "login-notify", {
       method: "POST",
@@ -175,7 +160,7 @@ describe("workspaceLogin", () => {
     expect(result.workspaceSlug).toBe("resolved-slug");
   });
 
-  it("keeps admin login successful when session or audit tracking fails", async () => {
+  it("keeps admin login successful when audit tracking fails", async () => {
     vi.mocked(getAuthState).mockReturnValue({
       role: "workspace_admin",
       sessionWorkspaceId: "ws-2",
@@ -187,13 +172,11 @@ describe("workspaceLogin", () => {
       error: "",
       data: { access_token: "at-1", refresh_token: "rt-1", workspace_slug: "acme" },
     });
-    vi.mocked(touchAccountSession).mockRejectedValueOnce(new Error("tracking unavailable"));
     vi.mocked(logAdminAction).mockRejectedValueOnce(new Error("audit unavailable"));
 
     await expect(workspaceLogin("admin@example.com", "hunter2")).resolves.toMatchObject({
       role: "workspace_admin",
     });
-    expect(touchAccountSession).toHaveBeenCalled();
     expect(logAdminAction).toHaveBeenCalled();
   });
 

--- a/src/services/auth/workspaceLogin.ts
+++ b/src/services/auth/workspaceLogin.ts
@@ -2,7 +2,6 @@ import { invokeEdgeFunction } from "../edgeFunctionClient";
 import { getWorkspaceState } from "../../store/workspaceState";
 import { getAuthState, setWorkspaceContext } from "../../store/authState";
 import { exchangeHttpSession, fetchHttpSessionSummary } from "../httpSessionService";
-import { touchAccountSession } from "../adminOpsService";
 import { logAdminAction } from "../auditLogService";
 import { applyHttpSessionSummary, resolveWorkspaceSlug } from "./sessionBootstrap";
 import { normalizeFunctionTarget, type LoginNotificationLocation } from "./types";
@@ -17,9 +16,13 @@ export const workspaceLogin=async(email:string,password:string,turnstileToken?:s
   const summary=await exchangeHttpSession({access_token:result.data.access_token,refresh_token:result.data.refresh_token}).catch(()=>fetchHttpSessionSummary());
   await applyHttpSessionSummary(summary); const current=getAuthState(); setWorkspaceContext(current.sessionWorkspaceId);
   if(current.role==="workspace_admin"){
-    try{await touchAccountSession({loginMethod:"password",loginLocation:"admin_login"});}catch{
-      // Session tracking must not block a successful sign in.
-    }
+    // Do not register an account_sessions row here: workspace_admin logins
+    // that aren't already on the workspace's subdomain get a full-page
+    // redirect (see Login.vue) to {slug}.app.itemtraxx.com, a different
+    // origin with its own localStorage device_id. Touching the session on
+    // this (pre-redirect) origin would create an orphan row that's never
+    // touched again, sharing the same auth_session_id as the real device
+    // row created on the destination page via its login_ctx handling.
     try{await logAdminAction({action_type:"admin_login",metadata:{email:email.trim()}});}catch{
       // Audit logging must not block a successful sign in.
     }

--- a/supabase/functions/admin-ops/actions/sessions.ts
+++ b/supabase/functions/admin-ops/actions/sessions.ts
@@ -434,6 +434,7 @@ export const handleSessionAction = async (
           device_id: string;
           device_label: string | null;
           user_agent: string | null;
+          auth_session_id?: string | null;
           login_method?: "password" | "magic_link" | "session_handoff" | null;
           login_location?: "regular_login" | "admin_login" | null;
           general_location?: string | null;
@@ -445,7 +446,7 @@ export const handleSessionAction = async (
     } = await context.adminClient
       .from("account_sessions")
       .select(
-        "id, device_id, device_label, user_agent, login_method, login_location, general_location, created_at, last_seen_at",
+        "id, device_id, device_label, user_agent, auth_session_id, login_method, login_location, general_location, created_at, last_seen_at",
       )
       .eq("workspace_id", context.workspaceId)
       .eq("profile_id", context.user.id)
@@ -459,7 +460,7 @@ export const handleSessionAction = async (
       sessionQuery = await context.adminClient
         .from("account_sessions")
         .select(
-          "id, device_id, device_label, user_agent, created_at, last_seen_at",
+          "id, device_id, device_label, user_agent, auth_session_id, created_at, last_seen_at",
         )
         .eq("workspace_id", context.workspaceId)
         .eq("profile_id", context.user.id)
@@ -469,7 +470,8 @@ export const handleSessionAction = async (
     }
     const { data, error } = sessionQuery;
     if (error) {
-      return isMissingSessionTable(error as RpcError)
+      return isMissingSessionTable(error as RpcError) ||
+          isMissingSessionAuthBindingColumn(error as RpcError)
         ? sessionUnavailable(context, 400)
         : context.jsonResponse(400, {
           error: "Unable to load active devices.",
@@ -483,14 +485,28 @@ export const handleSessionAction = async (
     }
     return context.jsonResponse(200, {
       data: {
-        sessions: Array.from(dedupedRows.values()).map((row) => ({
-          ...row,
-          login_method: row.login_method ?? null,
-          login_location: row.login_location ?? null,
-          general_location: row.general_location ?? null,
-          is_current: !!context.deviceSession.deviceId &&
-            row.device_id === context.deviceSession.deviceId,
-        })),
+        sessions: Array.from(dedupedRows.values()).map((row) => {
+          // A row counts as "current" if its device_id matches this request's
+          // device, or if it shares this request's auth_session_id. The
+          // latter covers sibling rows created from a different origin under
+          // the same Supabase auth session (e.g. the main app host vs a
+          // tenant's custom subdomain, which track device_id separately in
+          // per-origin localStorage) so they're never surfaced as a
+          // revokable "other" device.
+          const { auth_session_id: rowAuthSessionId, ...publicRow } = row;
+          return {
+            ...publicRow,
+            login_method: row.login_method ?? null,
+            login_location: row.login_location ?? null,
+            general_location: row.general_location ?? null,
+            is_current:
+              (!!context.deviceSession.deviceId &&
+                row.device_id === context.deviceSession.deviceId) ||
+              (!!context.authSessionBinding.sessionId &&
+                !!rowAuthSessionId &&
+                rowAuthSessionId === context.authSessionBinding.sessionId),
+          };
+        }),
       },
     });
   }
@@ -560,8 +576,19 @@ export const handleSessionAction = async (
     .eq("workspace_id", context.workspaceId)
     .eq("profile_id", context.user.id)
     .is("revoked_at", null);
-  if (!signOutCurrent && context.deviceSession.deviceId) {
-    query = query.neq("device_id", context.deviceSession.deviceId);
+  if (!signOutCurrent) {
+    // Prefer excluding by auth_session_id: the same Supabase auth session can
+    // back more than one account_sessions row (e.g. the main app host and a
+    // tenant's custom subdomain each track their own device_id in
+    // localStorage while sharing one login). Excluding only by device_id
+    // would leave the current browser's *other* row eligible for
+    // revocation, which then blocks this very request's session too. Fall
+    // back to device_id only when the auth session binding is unavailable.
+    if (context.authSessionBinding.sessionId) {
+      query = query.neq("auth_session_id", context.authSessionBinding.sessionId);
+    } else if (context.deviceSession.deviceId) {
+      query = query.neq("device_id", context.deviceSession.deviceId);
+    }
   }
   const { data, error } = await query.select("id");
   if (error) {

--- a/supabase/functions/admin-ops/actions/sessions_test.ts
+++ b/supabase/functions/admin-ops/actions/sessions_test.ts
@@ -849,6 +849,58 @@ Deno.test("handleSessionAction list_sessions dedupes rows and flags the current 
   assertEquals(sessions[1].is_current, false);
 });
 
+Deno.test("handleSessionAction list_sessions flags a sibling-origin row sharing the current auth session as current", async () => {
+  // Regression test: the main app host and a tenant's custom subdomain each
+  // track their own device_id in per-origin localStorage while sharing one
+  // Supabase auth session. A row for a *different* device_id must still be
+  // treated as "this session" when its auth_session_id matches, so it's
+  // never surfaced as a revokable "other" device and never strips out the
+  // browser's own row from a bulk "sign out others" exclusion.
+  const rows = [
+    {
+      id: "session-1",
+      device_id: "device-1",
+      device_label: "Front Desk",
+      user_agent: "ua-1",
+      auth_session_id: "auth-session-1",
+      created_at: "2026-07-01T00:00:00.000Z",
+      last_seen_at: "2026-07-02T00:00:00.000Z",
+    },
+    {
+      id: "session-2",
+      device_id: "device-2",
+      device_label: "Workspace subdomain",
+      user_agent: "ua-2",
+      auth_session_id: "auth-session-1",
+      created_at: "2026-07-01T00:00:00.000Z",
+      last_seen_at: "2026-07-01T00:00:00.000Z",
+    },
+    {
+      id: "session-3",
+      device_id: "device-3",
+      device_label: "Genuinely another device",
+      user_agent: "ua-3",
+      auth_session_id: "auth-session-other",
+      created_at: "2026-07-01T00:00:00.000Z",
+      last_seen_at: "2026-07-01T00:00:00.000Z",
+    },
+  ];
+  const { client } = makeClient(sequence([{ data: rows, error: null }]));
+  const response = await handleSessionAction(adminOpsContextFor("list_sessions", client));
+
+  assertEquals(response.status, 200);
+  const body = await responseBody(response);
+  const sessions = (body.data as { sessions: Array<Record<string, unknown>> }).sessions;
+  assertEquals(sessions.length, 3);
+  assertEquals(sessions[0].is_current, true);
+  assertEquals(sessions[1].is_current, true, "expected the sibling-origin row to be flagged current too");
+  assertEquals(sessions[2].is_current, false);
+  assert(
+    sessions.every((session) => !("auth_session_id" in session)),
+    "expected auth_session_id to never be exposed in the response",
+  );
+});
+
 Deno.test("handleSessionAction list_sessions retries without optional metadata columns", async () => {
   const { client, calls } = makeClient(
     sequence([
@@ -1021,10 +1073,33 @@ Deno.test("handleSessionAction revoke_all_sessions preserves the other-devices d
   assert(
     calls.some((call) =>
       call.operations.some((op) =>
+        op.method === "neq" && op.args[0] === "auth_session_id" &&
+        op.args[1] === "auth-session-1"
+      )
+    ),
+    "expected the current auth session to be excluded by default",
+  );
+});
+
+Deno.test("handleSessionAction revoke_all_sessions falls back to excluding by device_id when there is no auth session binding", async () => {
+  const { client, calls } = makeClient(
+    sequence([{ data: [{ id: "session-1" }, { id: "session-2" }], error: null }]),
+  );
+  const response = await handleSessionAction(
+    adminOpsContextFor("revoke_all_sessions", client, {}, {
+      authSessionBinding: { sessionId: null, issuedAt: null },
+    }),
+  );
+
+  assertEquals(response.status, 200);
+  assertEquals(await responseBody(response), { data: { revoked: 2 } });
+  assert(
+    calls.some((call) =>
+      call.operations.some((op) =>
         op.method === "neq" && op.args[0] === "device_id" && op.args[1] === "device-1"
       )
     ),
-    "expected the current device to be excluded by default",
+    "expected the current device to be excluded when no auth session binding is available",
   );
 });
 

--- a/tests/e2e/admin-settings-sessions.spec.ts
+++ b/tests/e2e/admin-settings-sessions.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+import {
+  mockAdminOps,
+  mockSystemStatus,
+  mockUnauthenticatedSession,
+  navigateApp,
+  setWorkspaceAdminSession,
+} from "./helpers/testHarness";
+
+test.describe("admin settings device sessions repro", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSystemStatus(page);
+    await mockUnauthenticatedSession(page);
+  });
+
+  test("bulk sign-out excludes current device and dropdown opens", async ({ page }) => {
+    const revokedAll: unknown[] = [];
+    const currentSession = {
+      id: "session-1",
+      device_id: "device-current",
+      device_label: "Admin laptop",
+      user_agent: null,
+      login_method: "password",
+      login_location: "admin_login",
+      general_location: "Portland, OR",
+      created_at: new Date().toISOString(),
+      last_seen_at: new Date().toISOString(),
+      is_current: true,
+    };
+    const remoteSession = {
+      id: "session-2",
+      device_id: "device-remote",
+      device_label: "Home laptop",
+      user_agent: null,
+      login_method: "magic_link",
+      login_location: "regular_login",
+      general_location: "Seattle, WA",
+      created_at: new Date().toISOString(),
+      last_seen_at: new Date().toISOString(),
+      is_current: false,
+    };
+    let revokedRemote = false;
+
+    await mockAdminOps(page);
+    await page.route(/\/functions(?:\/v1)?\/admin-ops(?:\?.*)?$/, async (route) => {
+      const body = route.request().postDataJSON() as { action?: string; payload?: Record<string, unknown> };
+      if (body.action === "list_sessions") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            data: { sessions: [currentSession, ...(revokedRemote ? [] : [remoteSession])] },
+          }),
+        });
+        return;
+      }
+      if (body.action === "revoke_all_sessions") {
+        revokedAll.push(body.payload);
+        revokedRemote = true;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ data: { revoked: 1 } }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto("/");
+    await page.evaluate(() => {
+      window.localStorage.setItem("itemtraxx:onboarding:v1:workspace_admin", new Date().toISOString());
+    });
+    await setWorkspaceAdminSession(page);
+    await navigateApp(page, "/admin/settings");
+
+    await expect(page.getByRole("heading", { name: "Active Devices" })).toBeVisible();
+    await expect(page.getByText("Home laptop")).toBeVisible();
+
+    // Three-dot dropdown check
+    const remoteActions = page.getByRole("button", { name: "Open actions for Home laptop" });
+    await expect(remoteActions).toBeVisible();
+    await remoteActions.click();
+    await expect(page.getByRole("menuitem", { name: "Revoke device" })).toBeVisible();
+    await page.keyboard.press("Escape");
+
+    // Bulk sign-out-others check
+    let confirmationSeen = false;
+    page.once("dialog", async (dialog) => {
+      confirmationSeen = true;
+      await dialog.accept();
+    });
+    await page.getByRole("button", { name: "Sign out all other devices" }).click();
+    expect(confirmationSeen).toBe(true);
+
+    await expect.poll(() => revokedAll.length).toBe(1);
+    // Give any polling/heartbeat logic a chance to react before asserting.
+    await page.waitForTimeout(1000);
+
+    // Current session must remain: no forced logout / termination banner, still on /admin/settings.
+    await expect(page).toHaveURL(/\/admin\/settings/);
+    await expect(page.getByText("Admin laptop")).toBeVisible();
+    await expect(page.getByText("This device")).toBeVisible();
+  });
+});


### PR DESCRIPTION
This pull request improves the handling of device sessions for workspace admin logins, ensuring more accurate session tracking and preventing accidental sign-out of the current session across different app origins. It also cleans up the code by removing unnecessary session registration logic during admin login and strengthens tests to cover edge cases with multiple origins.

**Session tracking and admin login logic:**

* Removed the call to `touchAccountSession` during workspace admin login in both `workspaceLogin.ts` and its tests, along with all related mocks and assertions. Session registration now happens only on the destination page after redirect, preventing the creation of orphaned device rows for admin logins that switch origins. [[1]](diffhunk://#diff-939fe76fcd10555b47094f39d894e405d1c3b92e704d608ed48bc3d820212ae8L5) [[2]](diffhunk://#diff-939fe76fcd10555b47094f39d894e405d1c3b92e704d608ed48bc3d820212ae8L20-R25) [[3]](diffhunk://#diff-d79ec0da222f8717c655dccdb1f89010cf53e3c22872e412ae01507c634ff7b5L21-L24) [[4]](diffhunk://#diff-d79ec0da222f8717c655dccdb1f89010cf53e3c22872e412ae01507c634ff7b5L39) [[5]](diffhunk://#diff-d79ec0da222f8717c655dccdb1f89010cf53e3c22872e412ae01507c634ff7b5L99) [[6]](diffhunk://#diff-d79ec0da222f8717c655dccdb1f89010cf53e3c22872e412ae01507c634ff7b5L125) [[7]](diffhunk://#diff-d79ec0da222f8717c655dccdb1f89010cf53e3c22872e412ae01507c634ff7b5L149-L168) [[8]](diffhunk://#diff-d79ec0da222f8717c655dccdb1f89010cf53e3c22872e412ae01507c634ff7b5L178-R163) [[9]](diffhunk://#diff-d79ec0da222f8717c655dccdb1f89010cf53e3c22872e412ae01507c634ff7b5L190-L196)

**Session management improvements (backend):**

* Updated `handleSessionAction` to use `auth_session_id` (when available) to identify the current session, not just `device_id`. This ensures that sessions from different origins but sharing the same authentication session are treated as the same device, preventing accidental sign-out. [[1]](diffhunk://#diff-29b8f31dddd1f36b1780db5b23ede0da6a8f6f237f8aa91b423d5b6bb1f5fa2bR437) [[2]](diffhunk://#diff-29b8f31dddd1f36b1780db5b23ede0da6a8f6f237f8aa91b423d5b6bb1f5fa2bL448-R449) [[3]](diffhunk://#diff-29b8f31dddd1f36b1780db5b23ede0da6a8f6f237f8aa91b423d5b6bb1f5fa2bL462-R463) [[4]](diffhunk://#diff-29b8f31dddd1f36b1780db5b23ede0da6a8f6f237f8aa91b423d5b6bb1f5fa2bL486-R509) [[5]](diffhunk://#diff-29b8f31dddd1f36b1780db5b23ede0da6a8f6f237f8aa91b423d5b6bb1f5fa2bL563-R592)
* Added logic to fall back to `device_id` only when `auth_session_id` is missing, for excluding the current session during bulk sign-out.

**Test coverage:**

* Added and updated tests in `sessions_test.ts` to verify that sibling-origin sessions with the same `auth_session_id` are correctly flagged as current, and that bulk sign-out operations exclude the correct session(s) based on session binding availability. [[1]](diffhunk://#diff-a88dce562413ca01837d5aa18b21fc8f60963bf8da7ba63e7b54548e82b4d309R852-R903) [[2]](diffhunk://#diff-a88dce562413ca01837d5aa18b21fc8f60963bf8da7ba63e7b54548e82b4d309R1071-R1093) [[3]](diffhunk://#diff-a88dce562413ca01837d5aa18b21fc8f60963bf8da7ba63e7b54548e82b4d309L1027-R1102)
* Added an end-to-end test to ensure that bulk sign-out from the admin settings page does not sign out the current device and that device session actions work as expected in the UI.