### PR TITLE
fix(auth): isolate device logout and recover revoked sessions

### DIFF
--- a/cloudflare/edge-proxy/src/index_contract_test.ts
+++ b/cloudflare/edge-proxy/src/index_contract_test.ts
@@ -270,7 +270,7 @@ Deno.test("session me refreshes a missing access token and logout remains best e
     if (url.includes("/rest/v1/profiles?")) {
       return Promise.resolve(Response.json([]));
     }
-    if (url.endsWith("/auth/v1/logout")) {
+    if (url.endsWith("/auth/v1/logout?scope=local")) {
       return Promise.reject(new Error("upstream logout unavailable"));
     }
     return Promise.resolve(new Response(null, { status: 500 }));
@@ -319,7 +319,14 @@ Deno.test("session me refreshes a missing access token and logout remains best e
   } finally {
     globalThis.fetch = originalFetch;
   }
-  const logoutCall = calls.find((call) => call.url.endsWith("/auth/v1/logout"));
+  const logoutCall = calls.find((call) =>
+    call.url.endsWith("/auth/v1/logout?scope=local")
+  );
+  assertEquals(
+    logoutCall?.url,
+    `${SUPABASE_URL}/auth/v1/logout?scope=local`,
+    "logout uses the local Supabase scope",
+  );
   assertEquals(
     new Headers(logoutCall?.init?.headers).get("authorization"),
     "Bearer access",

--- a/cloudflare/edge-proxy/src/session.ts
+++ b/cloudflare/edge-proxy/src/session.ts
@@ -440,7 +440,10 @@ const handleSessionLogout = async (
 ) => {
   const cookies = parseCookies(request);
   if (cookies.accessToken) {
-    await fetch(buildSupabaseUrl(env, "/auth/v1/logout"), {
+    // Supabase defaults logout to the global scope, which would invalidate
+    // every device for this user. The HttpOnly cookie belongs to only this
+    // browser, so revoke only the corresponding Supabase auth session.
+    await fetch(buildSupabaseUrl(env, "/auth/v1/logout?scope=local"), {
       method: "POST",
       headers: {
         apikey: env.SUPABASE_ANON_KEY,

--- a/cloudflare/edge-proxy/src/session_test.ts
+++ b/cloudflare/edge-proxy/src/session_test.ts
@@ -588,9 +588,22 @@ Deno.test("session refresh: staff profile with a matching live device session su
 
 // ---- logout ----
 
-Deno.test("session logout: with an access-token cookie notifies Supabase and always clears cookies", async () => {
-  const fetchMock = installFetch((url) => {
-    if (url.endsWith("/auth/v1/logout")) {
+Deno.test("session logout: with an access-token cookie revokes only this session and clears cookies", async () => {
+  // Model two independent Supabase sessions so this contract catches a
+  // regression to the API's global (default) logout scope.
+  const activeSupabaseSessions = new Set(["access-1", "access-2"]);
+  const fetchMock = installFetch((url, init) => {
+    const upstreamUrl = new URL(url);
+    if (upstreamUrl.pathname.endsWith("/auth/v1/logout")) {
+      const token = new Headers(init?.headers).get("authorization")?.replace(
+        /^Bearer\s+/i,
+        "",
+      );
+      if (upstreamUrl.searchParams.get("scope") === "local" && token) {
+        activeSupabaseSessions.delete(token);
+      } else {
+        activeSupabaseSessions.clear();
+      }
       return Promise.resolve(new Response(null, { status: 204 }));
     }
     return Promise.resolve(new Response("unexpected", { status: 500 }));
@@ -613,6 +626,21 @@ Deno.test("session logout: with an access-token cookie notifies Supabase and alw
     fetchMock.restore();
   }
   assertEquals(fetchMock.calls.length, 1, "logout notifies Supabase once");
+  assertEquals(
+    activeSupabaseSessions.has("access-1"),
+    false,
+    "logout revokes the current device session",
+  );
+  assertEquals(
+    activeSupabaseSessions.has("access-2"),
+    true,
+    "logout preserves the other device session",
+  );
+  assertEquals(
+    fetchMock.calls[0].url,
+    `${SUPABASE_URL}/auth/v1/logout?scope=local`,
+    "logout uses the local Supabase scope so other devices remain signed in",
+  );
   assertEquals(
     new Headers(fetchMock.calls[0].init?.headers).get("authorization"),
     "Bearer access-1",

--- a/src/composables/useAdminSessionLifecycle.spec.ts
+++ b/src/composables/useAdminSessionLifecycle.spec.ts
@@ -17,16 +17,18 @@ vi.mock("../services/adminOpsService", () => ({
 }));
 vi.mock("../services/authService", () => ({
   getPostSignOutUrl: vi.fn(),
+  signOut: vi.fn(),
 }));
 
 import { fetchHttpSessionSummary } from "../services/httpSessionService";
 import { touchAccountSession, validateAccountSession } from "../services/adminOpsService";
-import { getPostSignOutUrl } from "../services/authService";
+import { getPostSignOutUrl, signOut } from "../services/authService";
 
 const mockedFetchHttpSessionSummary = vi.mocked(fetchHttpSessionSummary);
 const mockedTouchAccountSession = vi.mocked(touchAccountSession);
 const mockedValidateAccountSession = vi.mocked(validateAccountSession);
 const mockedGetPostSignOutUrl = vi.mocked(getPostSignOutUrl);
+const mockedSignOut = vi.mocked(signOut);
 
 const ADMIN_IDLE_TIMEOUT_MS = 20 * 60 * 1000;
 const ADMIN_POLL_INTERVAL_MS = 45_000;
@@ -102,6 +104,7 @@ describe("useAdminSessionLifecycle", () => {
     mockedTouchAccountSession.mockReset().mockResolvedValue({ ok: true });
     mockedValidateAccountSession.mockReset().mockResolvedValue({ valid: true });
     mockedGetPostSignOutUrl.mockReset().mockReturnValue(null as never);
+    mockedSignOut.mockReset().mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -262,6 +265,35 @@ describe("useAdminSessionLifecycle", () => {
     await get().signInAgain();
 
     expect(router.replace).toHaveBeenCalledWith("/public-login");
+    wrapper.unmount();
+  });
+
+  it("clears the stale server session before navigating back to sign-in", async () => {
+    const auth = buildAuth({ isAuthenticated: true, role: "tenant_account", userId: "u1" });
+    const route = buildRoute("/checkout");
+    mockedGetPostSignOutUrl.mockReturnValue("/login");
+    const { wrapper, get, router } = mountHost({ auth, route });
+    await vi.advanceTimersByTimeAsync(0);
+
+    let releaseSignOut!: () => void;
+    const signOutStarted = new Promise<void>((resolve) => {
+      mockedSignOut.mockImplementationOnce(
+        () =>
+          new Promise<void>((release) => {
+            resolve();
+            releaseSignOut = release;
+          }),
+      );
+    });
+    const recovery = get().signInAgain();
+    await signOutStarted;
+
+    expect(mockedSignOut).toHaveBeenCalledTimes(1);
+    expect(router.replace).not.toHaveBeenCalled();
+
+    releaseSignOut();
+    await recovery;
+    expect(router.replace).toHaveBeenCalledWith("/login");
     wrapper.unmount();
   });
 

--- a/src/composables/useAdminSessionLifecycle.ts
+++ b/src/composables/useAdminSessionLifecycle.ts
@@ -124,13 +124,19 @@ export const useAdminSessionLifecycle = (options: AdminSessionLifecycleOptions) 
   const signInAgain = async () => {
     const recoveryRoute =
       options.sessionTermination.recoveryRoute ?? resolveRecoveryRouteFromPath(options.route.path);
+    const authService = await import("../services/authService");
     const getPostSignOutUrl =
       options.route.path.startsWith("/super-admin") || options.route.path.startsWith("/internal")
         ? null
-        : (await import("../services/authService")).getPostSignOutUrl;
+        : authService.getPostSignOutUrl;
     const nextUrl = getPostSignOutUrl === null ? null : getPostSignOutUrl();
     if (terminationRedirectTimer) window.clearTimeout(terminationRedirectTimer);
     terminationRedirectTimer = null;
+    // A revoked application session can still have a valid HttpOnly auth
+    // cookie. Clear that server session before navigating so a fresh tab
+    // cannot bootstrap the revoked identity and redirect back into the
+    // workspace again.
+    await authService.signOut();
     clearSessionTermination();
     options.closeMenu();
     if (nextUrl) {

--- a/src/services/auth/signOut.spec.ts
+++ b/src/services/auth/signOut.spec.ts
@@ -93,6 +93,16 @@ describe("signOut", () => {
     expect(clearAuthState).toHaveBeenCalledWith(true);
   });
 
+  it("continues clearing the HttpOnly session when local Supabase sign-out fails", async () => {
+    vi.mocked(signOutLocalSupabaseSession).mockRejectedValueOnce(new Error("local sign-out unavailable"));
+
+    await expect(signOut()).resolves.toBeUndefined();
+
+    expect(clearHttpSession).toHaveBeenCalledTimes(1);
+    expect(clearAuthState).toHaveBeenCalledWith(true);
+    expect(setWorkspaceContext).toHaveBeenCalledWith(null);
+  });
+
   it("continues cleanup even when clearing the HttpOnly cookie session fails", async () => {
     vi.mocked(clearHttpSession).mockRejectedValueOnce(new Error("cookie logout down"));
 

--- a/src/services/auth/signOut.ts
+++ b/src/services/auth/signOut.ts
@@ -27,7 +27,13 @@ export const signOut = async () => {
     }
   }
 
-  await signOutLocalSupabaseSession();
+  try {
+    await signOutLocalSupabaseSession();
+  } catch {
+    // The browser session is also represented by the HttpOnly cookie below;
+    // continue cleanup even when the local Supabase client has no session or
+    // cannot complete its best-effort sign-out call.
+  }
   await clearOfflineCheckoutQueue();
   await clearOfflineCheckoutWorkflow();
   clearOfflineConnectionState();

--- a/tests/e2e/session-recovery.spec.ts
+++ b/tests/e2e/session-recovery.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test, type BrowserContext } from "@playwright/test";
+import { navigateApp, waitForPublicAuthBootstrap } from "./helpers/testHarness";
+
+const unauthenticatedSummary = {
+  authenticated: false,
+  user: null,
+  profile: null,
+};
+
+const installSessionRecoveryMocks = async (context: BrowserContext) => {
+  let serverSession = false;
+  let logoutRequests = 0;
+
+  await context.route(/\/functions(?:\/v1)?\/system-status(?:\?.*)?$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "operational",
+        checks: { config: "ok", db: "ok", incident_io: "ok" },
+        incident_summary: "All systems operational.",
+        checked_at: new Date().toISOString(),
+        maintenance: { enabled: false, message: "" },
+      }),
+    });
+  });
+
+  await context.route("**/auth/session/me", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(serverSession
+        ? {
+            authenticated: true,
+            user: {
+              id: "user-session-recovery",
+              email: "admin@example.com",
+              last_sign_in_at: new Date().toISOString(),
+            },
+            profile: {
+              role: "workspace_admin",
+              workspace_id: "tenant-e2e",
+              auth_email: "admin@example.com",
+              is_active: true,
+            },
+          }
+        : unauthenticatedSummary),
+    });
+  });
+
+  await context.route("**/auth/session/logout", async (route) => {
+    logoutRequests += 1;
+    serverSession = false;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true }),
+    });
+  });
+
+  await context.route("**/rest/v1/workspaces?**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([{ id: "tenant-e2e", status: "active", slug: "tenant-e2e" }]),
+    });
+  });
+
+  await context.route(/\/functions(?:\/v1)?\/admin-ops(?:\?.*)?$/, async (route) => {
+    const body = (route.request().postDataJSON() as { action?: string }) ?? {};
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: body.action === "validate_session" ? { valid: false } : { ok: true },
+      }),
+    });
+  });
+
+  return {
+    setServerSession: () => {
+      serverSession = true;
+    },
+    getLogoutRequests: () => logoutRequests,
+  };
+};
+
+test("session-ended recovery clears the server session before a new tab bootstraps", async ({ browser }) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const mocks = await installSessionRecoveryMocks(context);
+
+  await page.goto("/");
+  await waitForPublicAuthBootstrap(page);
+  await page.evaluate(() => {
+    window.__itemtraxxTest?.setWorkspaceAdminSession("tenant-e2e");
+  });
+  // Keep the local Supabase sign-out deterministic; the browser session that
+  // must be cleared for this regression is the HttpOnly cookie session.
+  await page.evaluate(async () => {
+    const { supabase } = await import("/src/services/supabaseClient.ts");
+    Object.defineProperty(supabase.auth, "signOut", {
+      configurable: true,
+      value: async () => ({ error: null }),
+    });
+  });
+  mocks.setServerSession();
+  await navigateApp(page, "/admin");
+  await expect(page.getByRole("heading", { name: "This session has been terminated or expired." })).toBeVisible();
+
+  await page.getByRole("button", { name: "Sign in again" }).click();
+  await expect(page).toHaveURL(/\/login$/);
+  expect(mocks.getLogoutRequests()).toBe(1);
+
+  const freshTab = await context.newPage();
+  await freshTab.goto("/");
+  await waitForPublicAuthBootstrap(freshTab);
+  await expect(freshTab).toHaveURL(/\/$/);
+  await expect(
+    freshTab.getByRole("alertdialog").filter({ hasText: "Session Ended" }),
+  ).toHaveCount(0);
+
+  await context.close();
+});


### PR DESCRIPTION
## Summary

- Scope the edge session logout request to the current Supabase session so signing out on one device preserves other devices.
- Complete stale HttpOnly session cleanup before the revoked-session “Sign in again” navigation, preventing fresh-tab session-ended loops.
- Add Worker, unit, and Playwright regression coverage.

## Validation

- `npm run worker:test` — 110 passed
- `npm run test:unit` — 885 passed
- `npm run build` — passed
- Focused Playwright auth suite — 34 passed, 1 skipped
- `git diff --check` — passed